### PR TITLE
Requested workflow run

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -68,7 +68,7 @@ five-safes-crate:CreateActionInstrumentAndStatus
         }
         """ ;
         sh:severity sh:Violation ;
-        sh:message "`CreateAction` --> `instrument` MUST (also) reference `mainEntity`" ;
+        sh:message "`CreateAction` --> `instrument` MUST reference the same entity as `Root Data Entity` --> `mainEntity`" ;
     ] ;
     sh:sparql [
         a sh:SPARQLConstraint ;

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -49,17 +49,12 @@ five-safes-crate:RootDataEntityMentionsCreateAction
         a sh:PropertyShape ;
         sh:name "mentions" ;
         sh:path schema:mentions;
-        sh:minCount 1 ;
+        sh:qualifiedValueShape [
+            sh:class schema:CreateAction ;
+        ] ;
+        sh:qualifiedMinCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "`RootDataEntity` MUST have the `schema:mentions` property" ;
-    ] ;
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "mentions" ;
-        sh:path schema:mentions;
-        sh:class schema:CreateAction ;
-        sh:severity sh:Violation ;
-        sh:message "`RootDataEntity` --> `schema:mentions` MUST point to a `schema:CreateAction` entity" ;
+        sh:message "`RootDataEntity` MUST reference `CreateAction` through `schema:mentions`" ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -49,6 +49,7 @@ five-safes-crate:CreateActionInstrumentAndStatus
     a sh:NodeShape ;
     sh:name "CreateAction" ;
     sh:targetClass schema:CreateAction ;
+    sh:description "" ; 
 
     sh:property [
         a sh:PropertyShape ;
@@ -60,13 +61,14 @@ five-safes-crate:CreateActionInstrumentAndStatus
     ]  ;
     sh:sparql [
         a sh:SPARQLConstraint ;
-        sh:name "CreateActionInstrumentReferencesMainEntity" ;
+        sh:name "instrument" ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-        SELECT $this ?main ?root
+        SELECT $this ?main ?instrument
         WHERE {
             ?root schema:mainEntity ?main .
-            FILTER NOT EXISTS { $this schema:instrument ?main . }
+            $this schema:instrument ?instrument .
+            FILTER (?instrument != ?main)
         }
         """ ;
         sh:severity sh:Violation ;
@@ -75,6 +77,7 @@ five-safes-crate:CreateActionInstrumentAndStatus
     sh:sparql [
         a sh:SPARQLConstraint ;
         sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:name "object" ;
         sh:select """
             SELECT $this ?object
             WHERE {
@@ -83,5 +86,5 @@ five-safes-crate:CreateActionInstrumentAndStatus
             }
         """ ;
         sh:severity sh:Violation ;
-        sh:message "Each object in CreateAction MUST reference an existing entity." ;
+        sh:message "Each `object` in `CreateAction` MUST reference an existing entity." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -26,6 +26,24 @@ five-safes-crate:RootDataEntityMentionsCreateAction
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
     sh:targetClass ro-crate:RootDataEntity ;
+    sh:description "" ;
+
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:name "RO-Crate must contain CreateAction" ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+        SELECT $this
+        WHERE {
+            $this a schema:Dataset .
+            FILTER NOT EXISTS { 
+                ?action a schema:CreateAction .
+            }
+        }
+        """ ;
+        sh:severity sh:Violation ;
+        sh:message "RO-Crate MUST contain at least one `CreateAction` entity." ;
+    ] ;
 
     sh:property [
         a sh:PropertyShape ;

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -33,7 +33,7 @@ five-safes-crate:RootDataEntityMentionsCreateAction
         sh:path schema:mentions;
         sh:minCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "RootDataEntity MUST have the schema:mentions property" ;
+        sh:message "`RootDataEntity` MUST have the `schema:mentions` property" ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
@@ -41,7 +41,7 @@ five-safes-crate:RootDataEntityMentionsCreateAction
         sh:path schema:mentions;
         sh:class schema:CreateAction ;
         sh:severity sh:Violation ;
-        sh:message "RootDataEntity --> schema:mentions MUST point to a schema:CreateAction entity" ;
+        sh:message "`RootDataEntity` --> `schema:mentions` MUST point to a `schema:CreateAction` entity" ;
     ] .
 
 
@@ -56,17 +56,32 @@ five-safes-crate:CreateActionInstrumentAndStatus
         sh:path schema:instrument;
         sh:minCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "CreateAction MUST have the schema:instrument property" ;
+        sh:message "`CreateAction` MUST have the `schema:instrument` property" ;
     ]  ;
-    sh:constraint [
+    sh:sparql [
         a sh:SPARQLConstraint ;
+        sh:name "CreateActionInstrumentReferencesMainEntity" ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-        SELECT $this ?main
+        SELECT $this ?main ?root
         WHERE {
-            <./> schema:mainEntity ?main .
+            ?root schema:mainEntity ?main .
             FILTER NOT EXISTS { $this schema:instrument ?main . }
         }
         """ ;
         sh:severity sh:Violation ;
-        sh:message "CreateAction --> instrument MUST (also) reference mainEntity" ;
+        sh:message "`CreateAction` --> `instrument` MUST (also) reference `mainEntity`" ;
+    ] ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT $this ?object
+            WHERE {
+                $this schema:object ?object .
+                FILTER NOT EXISTS {  ?object a ?type . }
+            }
+        """ ;
+        sh:severity sh:Violation ;
+        sh:message "Each object in CreateAction MUST reference an existing entity." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -28,23 +28,6 @@ five-safes-crate:RootDataEntityMentionsCreateAction
     sh:targetClass ro-crate:RootDataEntity ;
     sh:description "" ;
 
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:name "RO-Crate must contain CreateAction" ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-        SELECT $this
-        WHERE {
-            $this a schema:Dataset .
-            FILTER NOT EXISTS { 
-                ?action a schema:CreateAction .
-            }
-        }
-        """ ;
-        sh:severity sh:Violation ;
-        sh:message "RO-Crate MUST contain at least one `CreateAction` entity." ;
-    ] ;
-
     sh:property [
         a sh:PropertyShape ;
         sh:name "mentions" ;
@@ -54,7 +37,7 @@ five-safes-crate:RootDataEntityMentionsCreateAction
         ] ;
         sh:qualifiedMinCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "`RootDataEntity` MUST reference `CreateAction` through `schema:mentions`" ;
+        sh:message "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`" ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:RootDataEntityMentionsCreateAction
+    a sh:NodeShape ;
+    sh:name "RootDataEntity" ;
+    sh:targetClass ro-crate:RootDataEntity ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "mentions" ;
+        sh:path schema:mentions;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "RootDataEntity MUST have the schema:mentions property" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "mentions" ;
+        sh:path schema:mentions;
+        sh:class schema:CreateAction ;
+        sh:severity sh:Violation ;
+        sh:message "RootDataEntity --> schema:mentions MUST point to a schema:CreateAction entity" ;
+    ] .
+
+
+five-safes-crate:CreateActionInstrumentAndStatus
+    a sh:NodeShape ;
+    sh:name "CreateAction" ;
+    sh:targetClass schema:CreateAction ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "instrument" ;
+        sh:path schema:instrument;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "CreateAction MUST have the schema:instrument property" ;
+    ]  ;
+    sh:constraint [
+        a sh:SPARQLConstraint ;
+        sh:select """
+        SELECT $this ?main
+        WHERE {
+            <./> schema:mainEntity ?main .
+            FILTER NOT EXISTS { $this schema:instrument ?main . }
+        }
+        """ ;
+        sh:severity sh:Violation ;
+        sh:message "CreateAction --> instrument MUST (also) reference mainEntity" ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -26,6 +26,7 @@
 five-safes-crate:CreateActionShouldHaveObjectProperty
     a sh:NodeShape ;
     sh:targetClass schema:CreateAction ;
+    sh:name "CreateAction" ;
     sh:property [
         sh:path schema:object ;
         sh:minCount 1 ;

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# CreateAction SHOULD have object property with minimum cardinality 1
+five-safes-crate:CreateActionShouldHaveObjectProperty
+    a sh:NodeShape ;
+    sh:targetClass schema:CreateAction ;
+    sh:property [
+        sh:path schema:object ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Warning ;
+        sh:message "`CreateAction` SHOULD have the property `object` with IRI values." ;
+    ] .

--- a/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
@@ -160,7 +160,7 @@
             "@type": "PropertyValue",
             "name": "tre72",
             "value": "project81"
-        },        
+        },
         {
             "@id": "input1.txt",
             "@type": "File",

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -46,7 +46,7 @@ def test_rocrate_does_not_have_createaction():
     )
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test, SPARQL_PREFIXES
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- MUST fails tests
+
+
+def test_rootdataentity_does_not_have_mentions_property():
+    """
+    Test a Five Safes Crate where RootDataEntity does not have the property mentions.
+    (We remove the property mentions from the RootDFataEntity entity)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            <./> schema:mentions ?o .
+        }
+        WHERE {
+            <./> schema:mentions ?o .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RootDataEntity"],
+        expected_triggered_issues=[
+            "`RootDataEntity` MUST have the `schema:mentions` property"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_rootdataentity_does_not_mention_createaction_entity():
+    """
+    Test a Five Safes Crate where RootDataEntity --> mentions does not reference
+    a CreateAction entity.
+    (We replace the CreateAction entity with a literal)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            <./> schema:mentions ?o .
+        }
+        INSERT {
+            <./> schema:mentions "This is not a CreateAction entity" .
+        }
+        WHERE {
+            <./> schema:mentions ?o .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RootDataEntity"],
+        expected_triggered_issues=[
+            "`RootDataEntity` --> `schema:mentions` MUST point to a `schema:CreateAction` entity"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_createaction_does_not_have_instrument_property():
+    """
+    Test a Five Safes Crate where `CreateAction` does not have the property `instrument`.
+    (We remove the property `instrument` from the `CreateAction` entity)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            ?action schema:instrument ?o .
+        }
+        WHERE {
+           ?action schema:instrument ?o ;
+                   a schema:CreateAction .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_issues=[
+            "`CreateAction` MUST have the `schema:instrument` property"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_createaction_does_not_reference_mainentity_via_instrument():
+    """
+    Test a Five Safes Crate where `CreateAction` --> `instrument` does not
+    reference `mainEntity`.
+    (We replace `mainEntity` with a literal as the object of `CreateAction` --> `instrument`)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            ?action schema:instrument ?o .
+        }
+        INSERT {
+            ?action schema:instrument "This is not the mainEntity" .
+        }
+        WHERE {
+           ?action schema:instrument ?o ;
+                   a schema:CreateAction .
+        }
+        
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_issues=[
+            "`CreateAction` --> `instrument` MUST (also) reference `mainEntity`"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -139,7 +139,6 @@ def test_createaction_does_not_reference_mainentity_via_instrument():
            ?action schema:instrument ?o ;
                    a schema:CreateAction .
         }
-        
         """
     )
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -81,41 +81,7 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST have the `schema:mentions` property"
-        ],
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_rootdataentity_does_not_mention_createaction_entity():
-    """
-    Test a Five Safes Crate where RootDataEntity --> mentions does not reference
-    a CreateAction entity.
-    (We replace the CreateAction entity with a literal)
-    """
-    sparql = (
-        SPARQL_PREFIXES
-        + """
-        DELETE {
-            <./> schema:mentions ?o .
-        }
-        INSERT {
-            <./> schema:mentions "This is not a CreateAction entity" .
-        }
-        WHERE {
-            <./> schema:mentions ?o .
-        }
-        """
-    )
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.REQUIRED,
-        expected_validation_result=False,
-        expected_triggered_requirements=["RootDataEntity"],
-        expected_triggered_issues=[
-            "`RootDataEntity` --> `schema:mentions` MUST point to a `schema:CreateAction` entity"
+            "`RootDataEntity` MUST reference `CreateAction` through `schema:mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -46,7 +46,7 @@ def test_rocrate_does_not_have_createaction():
     )
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_result,
+        rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -153,3 +153,72 @@ def test_createaction_does_not_reference_mainentity_via_instrument():
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
+
+
+def test_createaction_object_does_not_reference_existing_entities():
+    """
+    Test a Five Safes Crate where `CreateAction` --> `object` does not
+    reference an existing entity in the RO-Crate.
+    (We replace the objects of `CreateAction` --> `object` with a literal.`)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            ?action schema:object ?o .
+        }
+        INSERT {
+            ?action schema:object "This is not an entity in the RO-Crate" .
+        }
+        WHERE {
+           ?action schema:object ?o ;
+                   a schema:CreateAction .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_issues=[
+            "Each `object` in `CreateAction` MUST reference an existing entity."
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+# ----- SHOULD fails tests
+
+
+def test_createaction_does_not_have_object_property():
+    """
+    Test a Five Safes Crate where `CreateAction` does not have the property `object`.
+    (We remove the property `object` from `CreateAction`)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            ?action schema:object ?o .
+        }
+        WHERE {
+           ?action schema:object ?o ;
+                   a schema:CreateAction .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_issues=[
+            "`CreateAction` SHOULD have the property `object` with IRI values."
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -180,7 +180,7 @@ def test_createaction_does_not_reference_mainentity_via_instrument():
         expected_validation_result=False,
         expected_triggered_requirements=["CreateAction"],
         expected_triggered_issues=[
-            "`CreateAction` --> `instrument` MUST (also) reference `mainEntity`"
+            "`CreateAction` --> `instrument` MUST reference the same entity as `Root Data Entity` --> `mainEntity`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -25,6 +25,39 @@ logger = logging.getLogger(__name__)
 # ----- MUST fails tests
 
 
+def test_rocrate_does_not_have_createaction():
+    """
+    Test a Five Safes Crate where no `CreateAction` entity exists.
+    (We remove the entire CreateAction entity from the RO-Crate)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            ?action ?p ?o .
+            ?s ?p2 ?action .
+        }
+        WHERE {
+            ?action a schema:CreateAction .
+            ?action ?p ?o .
+            OPTIONAL { ?s ?p2 ?action . }
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RootDataEntity"],
+        expected_triggered_issues=[
+            "RO-Crate MUST contain at least one `CreateAction` entity."
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
 def test_rootdataentity_does_not_have_mentions_property():
     """
     Test a Five Safes Crate where RootDataEntity does not have the property mentions.

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -51,7 +51,7 @@ def test_rocrate_does_not_have_createaction():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "RO-Crate MUST contain at least one `CreateAction` entity."
+            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -61,7 +61,7 @@ def test_rocrate_does_not_have_createaction():
 def test_rootdataentity_does_not_have_mentions_property():
     """
     Test a Five Safes Crate where RootDataEntity does not have the property mentions.
-    (We remove the property mentions from the RootDFataEntity entity)
+    (We remove the property mentions from the RootDataEntity entity)
     """
     sparql = (
         SPARQL_PREFIXES
@@ -81,7 +81,40 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference `CreateAction` through `schema:mentions`"
+            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_rootdataentity_does_not_mention_create_action():
+    """
+    Test a Five Safes Crate where `RootDataEntity` does not `mention` a `CreateAction` entity.
+    (We replace the object of RooDataEntity --> mentions with a string literal).
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        DELETE {
+            <./> schema:mentions ?o .
+        }
+        INSERT {
+            <./> schema:mentions "This is not a CreateAction entity" .
+        }
+        WHERE {
+            <./> schema:mentions ?o .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RootDataEntity"],
+        expected_triggered_issues=[
+            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,


### PR DESCRIPTION
This PR addresses #30

### Rules implemented

| # | Description | sh:severity |
|---|--------------|-------------|
| 1 | RO-Crate MUST contain at least one `CreateAction` entity. (i) | sh:Violation |
| 2 | `RootDataEntity` MUST have the `schema:mentions` property | sh:Violation |
| 3 | `RootDataEntity` --> `schema:mentions` MUST point to a `schema:CreateAction` entity| sh:Violation |
| 4 | `CreateAction` MUST have the `schema:instrument` property | sh:Violation|
| 5 | `CreateAction` --> `instrument` MUST (also) reference `mainEntity` | sh:Violation |
| 6 | `CreateAction` SHOULD have the property `object` with IRI values. | sh:Warning |
| 7 | Each `object` in `CreateAction` MUST reference an existing entity. | sh:Violation | 

(i) This rule is implicitly contained in rules 2 and 3, so it was not explicitly coded in SHACL.
However, we did create a python test for it.

---

### Rules NOT implemented
The following rule was not implemented due to ambiguity on how to define "UUID-based URI fragment"


| Description | sh:severity|
|--------|--------|
| The @id of `CreateAction` SHOULD be a UUID-based URI fragment (e.g. #query-...), different from the BagIt External-Identifier. | sh:Warning |