### PR TITLE
Implemented remaining rule for Inputs.

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix bioschemas: <https://bioschemas.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+
+five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
+    a sh:NodeShape ;
+    sh:name "Input" ;
+    sh:description "" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this WHERE {
+              ?action a schema:CreateAction ;
+                      schema:object ?this .
+            }
+        """
+    ] ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:name "exampleOfWork" ;
+        sh:description "Input SHOULD reference a FormalParameter using exampleOfWork" ;
+        
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT $this WHERE {
+              FILTER NOT EXISTS {
+                $this schema:exampleOfWork ?par .
+                ?par a bioschemas:FormalParameter .
+              }
+            }
+        """ ;
+        sh:severity sh:Warning ;
+        sh:message "Input SHOULD reference a FormalParameter using exampleOfWork" ;
+    ] .

--- a/tests/integration/profiles/five-safes-crate/test_5src_9_inputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_9_inputs.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test, SPARQL_PREFIXES
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- SHOULD fails tests
+
+
+def test_input_does_not_reference_formalparameter():
+    """
+    Test a Five Safes Crate where an input entity does not reference a
+    `bioschemas:FormalParameter using `schema:exampleOfWork`.
+    (We replace tjhe ?object of input --> exampleOfWork  with a literal)
+    """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
+        PREFIX bioschemas: <https://bioschemas.org/>
+        DELETE {
+            ?input schema:exampleOfWork ?formalParameter .
+        }
+        INSERT {
+            ?input schema:exampleOfWork "not-a-formal-parameter" .
+        }
+        WHERE {
+            ?input schema:exampleOfWork ?formalParameter .
+            ?formalParameter a bioschemas:FormalParameter .
+            ?action a schema:CreateAction ;
+                    schema:object ?input .
+        }
+        """
+    )
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["Input"],
+        expected_triggered_issues=[
+            "Input SHOULD reference a FormalParameter using exampleOfWork"
+        ],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )


### PR DESCRIPTION
This PR addresses #33 

## Rules Implemented in this PR

|  Description | sh:severity |
|--------------|--------------|
| Input entity SHOULD reference a corresponding `FormalParameter` using `exampleOfWork` | sh:Warning |

## Rules pertaining to Input entities already implemented in other PRs
The following rules (and corresponding tests) have been implemented as part of #31 

|  Description | sh:severity |
|--------------|--------------|
| `CreateAction` SHOULD have an `object` property| sh:Warning |
| `CreateAction` --> `object` MUST list one or more input entities | sh:Violation |


## Rules that have not been implemented
Thew following rule may not be implementable through SHACL.

|  Description | sh:severity |
|--------------|--------------|
| The name of a `FormalParameter` SHOULD match names expected by the referenced Workflow Crate (used by engine for binding) | sh:Warning |