### PR TITLE
Implement Disclosure Phase Ruleset

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/may/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/8_disclosure_phase.ttl
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:DisclosureObjectHasStartTimeIfBegun
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck ;
+                        schema:actionStatus ?status .
+                FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "StartTime" ;
+        sh:path schema:startTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:severity sh:Info ;
+        sh:description "Disclosure object MAY have startTime property with RFC 3339 full datetime string if action began." ;
+        sh:message "Disclosure object MAY have startTime property with RFC 3339 full datetime string if action began." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
@@ -52,7 +52,7 @@ five-safes-crate:DisclosureObjectHasDescriptiveName
     sh:property [
         sh:path rdf:type ;
         sh:minCount 1 ;
-        sh:class schema:AssessAction ;
+        sh:hasValue schema:AssessAction;
         sh:severity sh:Violation ;
         sh:message "DisclosureCheck MUST be a `schema:AssessAction`." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:DisclosureObjectHasDescriptiveName
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck .
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:minLength 20 ;
+        sh:severity sh:Violation ;
+        sh:message "DisclosureCheck MUST have a name string of at least 20 characters." ;
+    ] ;
+
+    sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:class schema:AssessAction ;
+        sh:severity sh:Violation ;
+        sh:message "DisclosureCheck MUST be a `schema:AssessAction`." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
@@ -23,7 +23,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:DisclosureObjectHasDescriptiveName
+five-safes-crate:DisclosureObjectHasDescriptiveNameAndIsAssessAction
     a sh:NodeShape ;
     sh:name "DisclosureCheck" ;
     sh:description "DisclosureCheck" ;
@@ -42,19 +42,25 @@ five-safes-crate:DisclosureObjectHasDescriptiveName
     ] ;
 
     sh:property [
-        sh:path schema:name ;
-        sh:datatype xsd:string ;
-        sh:minLength 20 ;
-        sh:severity sh:Violation ;
-        sh:message "DisclosureCheck MUST have a name string of at least 20 characters." ;
-    ] ;
-
-    sh:property [
+        sh:a sh:PropertyShape ;
+        sh:name "AssessAction" ;
+        sh:description "DisclosureCheck MUST be a `schema:AssessAction`." ;
         sh:path rdf:type ;
         sh:minCount 1 ;
         sh:hasValue schema:AssessAction;
         sh:severity sh:Violation ;
         sh:message "DisclosureCheck MUST be a `schema:AssessAction`." ;
+    ] ;
+
+    sh:property [
+        sh:a sh:PropertyShape ;
+        sh:name "name" ;
+        sh:description "DisclosureCheck MUST have a name string of at least 20 characters." ;
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:minLength 20 ;
+        sh:severity sh:Violation ;
+        sh:message "DisclosureCheck MUST have a name string of at least 20 characters." ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
@@ -56,3 +56,38 @@ five-safes-crate:DisclosureObjectHasDescriptiveName
         sh:severity sh:Violation ;
         sh:message "DisclosureCheck MUST be a `schema:AssessAction`." ;
     ] .
+
+
+five-safes-crate:DisclosureObjectHasActionStatus
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck ;
+                      schema:actionStatus ?status .
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "actionStatus" ;
+        sh:description "The value of actionStatus MUST be one of the allowed values." ;
+        sh:path schema:actionStatus ;
+        sh:in (
+            "http://schema.org/PotentialActionStatus"
+            "http://schema.org/ActiveActionStatus"
+            "http://schema.org/CompletedActionStatus"
+            "http://schema.org/FailedActionStatus"
+        ) ;
+        sh:severity sh:Violation ;
+        sh:message "The value of actionStatus MUST be one of the allowed values." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:RootDataEntityShouldMentionDisclosureObject
+    a sh:NodeShape ;
+    sh:name "RootDataEntity" ;
+    sh:targetClass ro-crate:RootDataEntity ;
+    sh:description "RootDataEntity SHOULD mention a disclosure object." ;
+
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:name "mentions" ;
+        sh:description "RootDataEntity SHOULD mention a disclosure object." ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp: <https://w3id.org/shp#>
+            SELECT $this
+            WHERE {
+                FILTER NOT EXISTS{
+                    $this schema:mentions ?action .
+                    ?action a schema:AssessAction ;
+                            schema:additionalType shp:DisclosureCheck .
+                }
+            }
+        """ ;
+        sh:severity sh:Warning ;
+        sh:message "RootDataEntity SHOULD mention a disclosure object." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
@@ -48,3 +48,32 @@ five-safes-crate:RootDataEntityShouldMentionDisclosureObject
         sh:severity sh:Warning ;
         sh:message "RootDataEntity SHOULD mention a disclosure object." ;
     ] .
+
+
+five-safes-crate:DisclosureObjectHasActionStatus
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck .
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "ActionStatus" ;
+        sh:description "The DisclosureCheck SHOULD have actionStatus property." ;
+        sh:path schema:actionStatus ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "The DisclosureCheck SHOULD have actionStatus property." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
@@ -77,3 +77,78 @@ five-safes-crate:DisclosureObjectHasActionStatus
         sh:severity sh:Warning ;
         sh:message "The DisclosureCheck SHOULD have actionStatus property." ;
     ] .
+
+
+
+five-safes-crate:DisclosureObjectHasStartTimeIfBegun
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck ;
+                        schema:actionStatus ?status .
+                FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "StartTime" ;
+        sh:path schema:startTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:severity sh:Warning ;
+        sh:description "Disclosure object SHOULD have startTime property with a valid datetime if action began." ;
+        sh:message "Disclosure object SHOULD have startTime property with a valid datetime if action began." ;
+    ] .
+
+
+
+five-safes-crate:DisclosureObjectHasEndTimeIfcompletedOrFailed
+    a sh:NodeShape ;
+    sh:name "DisclosureCheck" ;
+    sh:description "DisclosureCheck" ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX shp:    <https://w3id.org/shp#>
+
+            SELECT ?this
+            WHERE {
+                ?this schema:additionalType shp:DisclosureCheck ;
+                        schema:actionStatus ?status .
+                FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "EndTime" ;
+        sh:path schema:endTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:severity sh:Warning ;
+        sh:description "Disclosure object SHOULD have endTime property with a valid datetetime if action completed of failed." ;
+        sh:message "Disclosure object SHOULD have endTime property with a valid datetime if action completed of failed." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/8_disclosure_phase.ttl
@@ -79,45 +79,6 @@ five-safes-crate:DisclosureObjectHasActionStatus
     ] .
 
 
-
-five-safes-crate:DisclosureObjectHasStartTimeIfBegun
-    a sh:NodeShape ;
-    sh:name "DisclosureCheck" ;
-    sh:description "DisclosureCheck" ;
-
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:select """
-            PREFIX schema: <http://schema.org/>
-            PREFIX shp:    <https://w3id.org/shp#>
-
-            SELECT ?this
-            WHERE {
-                ?this schema:additionalType shp:DisclosureCheck ;
-                        schema:actionStatus ?status .
-                FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus",
-                    "http://schema.org/ActiveActionStatus"
-                ))
-            }
-        """ ;
-    ] ;
-
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "StartTime" ;
-        sh:path schema:startTime ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
-        sh:severity sh:Warning ;
-        sh:description "Disclosure object SHOULD have startTime property with a valid datetime if action began." ;
-        sh:message "Disclosure object SHOULD have startTime property with a valid datetime if action began." ;
-    ] .
-
-
-
 five-safes-crate:DisclosureObjectHasEndTimeIfcompletedOrFailed
     a sh:NodeShape ;
     sh:name "DisclosureCheck" ;

--- a/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
@@ -160,7 +160,7 @@
             "@type": "PropertyValue",
             "name": "tre72",
             "value": "project81"
-        },        
+        },
         {
             "@id": "input1.txt",
             "@type": "File",
@@ -303,6 +303,7 @@
                 "@id": "https://w3id.org/shp#DisclosureCheck"
             },
             "name": "Disclosure check of workflow results: approved",
+            "startTime": "2023-04-24T00:00:00+01:00",
             "endTime": "2023-04-25T16:00:00+01:00",
             "object": {
                 "@id": "./"

--- a/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
@@ -194,7 +194,7 @@ def test_5src_disclosure_object_not_mentioned_by_root_data_entity():
     )
 
 
-def test_5src_disclosure_object_with_no_axction_status():
+def test_5src_disclosure_object_with_no_action_status():
     sparql = """
         PREFIX schema: <http://schema.org/>
         PREFIX shp:    <https://w3id.org/shp#>
@@ -204,36 +204,6 @@ def test_5src_disclosure_object_with_no_axction_status():
         }
         WHERE {
             ?s schema:additionalType shp:DisclosureCheck .
-        }
-        """
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.RECOMMENDED,
-        expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_5src_disclosure_object_has_no_start_time_if_begun():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX shp:    <https://w3id.org/shp#>
-
-        DELETE {
-            ?s schema:startTime ?o .
-        }
-        WHERE {
-            ?s schema:additionalType shp:DisclosureCheck ;
-               schema:actionStatus ?status .
-               FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus",
-                    "http://schema.org/ActiveActionStatus"
-                ))
         }
         """
 
@@ -334,6 +304,39 @@ def test_5src_disclosure_object_has_no_properly_formatted_end_time_if_ended():
     do_entity_test(
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+# ----- MAY fails tests
+
+
+def test_5src_disclosure_object_has_no_start_time_if_begun():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:startTime ?o .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.OPTIONAL,
         expected_validation_result=False,
         expected_triggered_requirements=None,
         expected_triggered_issues=None,

--- a/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test, SPARQL_PREFIXES
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- MUST fails tests
+
+
+def test_5src_disclosure_object_with_no_name():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        WHERE {
+            ?this schema:additionalType shp:DisclosureCheck ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_with_name_not_string():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        INSERT {
+            ?this schema:name 123 .
+        }
+        WHERE {
+            ?this schema:additionalType shp:DisclosureCheck ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_with_not_long_enough_name():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        INSERT {
+            ?this schema:name "Too short" .
+        }
+        WHERE {
+            ?this schema:additionalType shp:DisclosureCheck ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_not_an_assess_action():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this rdf:type ?o .
+        }
+        INSERT {
+            ?this rdf:type "Not an AssessAction type" .
+        }
+        WHERE {
+            ?this rdf:type schema:AssessAction ;
+                  schema:additionalType shp:DisclosureCheck .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_with_no_proper_action_status():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:actionStatus ?o .
+        }
+        INSERT {
+            ?this schema:actionStatus "This is not a proper actionStatus" .
+        }
+        WHERE {
+            ?this schema:actionStatus ?o ;
+                  schema:additionalType shp:DisclosureCheck .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+# ----- SHOULD fails tests
+
+
+def test_5src_disclosure_object_not_mentioned_by_root_data_entity():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            <./> schema:mentions ?o .
+        }
+        WHERE {
+            ?o schema:additionalType shp:DisclosureCheck .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_with_no_axction_status():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:actionStatus ?o .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_has_no_start_time_if_begun():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:startTime ?o .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_has_no_properly_formatted_start_time_if_begun():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:startTime ?o .
+        }
+        INSERT {
+            ?s schema:startTime "1st Dec '25 @ 10:00:00" .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_has_no_end_time_if_ended():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:endTime ?o .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_disclosure_object_has_no_properly_formatted_end_time_if_ended():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>
+
+        DELETE {
+            ?s schema:endTime ?o .
+        }
+        INSERT {
+            ?s schema:endTime "1st Dec '25 @ 10:00:00" .
+        }
+        WHERE {
+            ?s schema:additionalType shp:DisclosureCheck ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
@@ -16,7 +16,7 @@ import logging
 
 from rocrate_validator.models import Severity
 from tests.ro_crates import ValidROC
-from tests.shared import do_entity_test, SPARQL_PREFIXES
+from tests.shared import do_entity_test
 
 # set up logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This PR addresses #38.

## Rules Implemented

| # | Description | sh:Severity|
| -- |------------- | ----------- |
| 1 | The Root Data Entity SHOULD mention a disclosure object   |   sh:Warning   |
| 2 | MUST provide a human-readable summary of the disclosure status | sh:Violation |
| 3 | Disclosure Phase MUST be of type AssessAction | sh:Violation |
| 4 | SHOULD be set to https://w3id.org/shp#DisclosureCheck (i).  | sh:Warning |
| 5 | AssesAction SHOULD have the property schema:actionStatus | sh:Warning |
| 6 | AssessAction --> actionStatus MUST have one of the allowed values | sh:Violation |
| 7 | AssessAction SHOULD have startTime if action began **(ii)** | sh:Warning |
| 8 | AssessAction SHOULD have startTime if action completed or failed | sh:Warning |

(i) This rule is implicitly included in rule 1, so it does not have a dedicated SHACL implementation.
**(ii) The five-safes-crate-result had to be modified as it did not have the startTime property for the AssessAction entity (while it had the endTime property).**


## Rules Not Implemented

| # | Description | sh:Severity|
| -- |------------- | ----------- |
| 9 | If disclosure phase failed, its content such as workflow results MUST NOT be included in the crate returned to the user (iii).   |   sh:Violation|
| 10 | If disclosure phase failed, CreateAction and associated result data entities SHOULD be removed from the metadata file (iv).  | sh:Warning |

(iii) This rule may need to be checked manually
(iv) This rule need the creation of a new ro-crate corresponding to a failed status for the disclosure phase.
