### PR TITLE
Implemented rules for the Workflow Execution Phase.

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
@@ -17,43 +17,15 @@
 @prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix schema: <http://schema.org/> .
-@prefix purl: <http://purl.org/dc/terms/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix validator: <https://github.com/crs4/rocrate-validator/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-
-five-safes-crate:RootDataEntityShouldMentionWorkflow 
-    a sh:NodeShape ;
-    sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)." ;
-    sh:targetClass ro-crate:RootDataEntity ;
-    sh:sparql [
-        a sh:SPARQLConstraint ; 
-        sh:name "mentions" ;
-        sh:select """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT $this 
-        WHERE {
-            
-            FILTER NOT EXISTS {
-                $this schema:mentions ?workflowExecution .
-                ?workflowExecution rdf:type schema:CreateAction .
-            }
-        }
-        """ ;
-      sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)." ;
-   ] .
-
-
-
-five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
+five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The workflow execution object SHOULD have an endTime property if it has ended." ;
+    sh:description "The workflow execution object MAY have a startTime if execution was initiated." ;
 
     sh:target [
         a sh:SPARQLTarget ;
@@ -67,7 +39,8 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
                       schema:actionStatus ?status .
                 FILTER(?status IN (
                     "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus"
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
                 ))
             }
         """ ;
@@ -75,11 +48,11 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
 
     sh:property [
         a sh:PropertyShape ;
-        sh:name "EndTime" ;
-        sh:path schema:endTime ;
+        sh:name "StartTime" ;
+        sh:path schema:startTime ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:severity sh:Warning ;
-        sh:description "The workflow execution object SHOULD have an endTime property if it has ended." ;
-        sh:message "The workflow execution object SHOULD have an endTime property if it has ended." ;
+        sh:severity sh:Info ;
+        sh:description "The workflow execution object MAY have a startTime if execution was initiated." ;
+        sh:message "The workflow execution object MAY have a startTime if execution was initiated." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -45,25 +45,13 @@ five-safes-crate:WorkflowexecutionObjectHasCompliantStartTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
     sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
-
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:select """
-            PREFIX schema: <http://schema.org/>
-            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-            SELECT ?this
-            WHERE {
-                ?this rdf:type schema:CreateAction ;
-                      schema:startTime ?time .
-            }
-        """ ;
-    ] ;
+    sh:targetClass schema:CreateAction ;
 
     sh:property [
         a sh:PropertyShape ;
         sh:name "StartTime" ;
         sh:path schema:startTime ;
+        sh:minCount 0 ;
         sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
         sh:message "The startTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
@@ -74,25 +62,13 @@ five-safes-crate:WorkflowexecutionObjectHasCompliantEndTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
     sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
-
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:select """
-            PREFIX schema: <http://schema.org/>
-            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-            SELECT ?this
-            WHERE {
-                ?this rdf:type schema:CreateAction ;
-                      schema:endTime ?time .
-            }
-        """ ;
-    ] ;
+    sh:targetClass schema:CreateAction ;
 
     sh:property [
         a sh:PropertyShape ;
         sh:name "EndTime" ;
         sh:path schema:endTime ;
+        sh:minCount 0 ;
         sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
         sh:message "The endTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -113,4 +113,23 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
         sh:message "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
     ] .
 
-    
+
+five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
+    a sh:NodeShape ;
+    sh:name "WorkflowExecution" ;
+    sh:targetClass schema:CreateAction ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:minCount 1 ;
+        sh:name "actionStatus" ;
+        sh:description "WorkflowExecution MUST have an actionStatus with an allowed value." ;
+        sh:path schema:actionStatus ;
+        sh:in (
+            "http://schema.org/PotentialActionStatus"
+            "http://schema.org/ActiveActionStatus"
+            "http://schema.org/CompletedActionStatus"
+            "http://schema.org/FailedActionStatus"
+        ) ;
+        sh:severity sh:Violation ;
+        sh:message "WorkflowExecution MUST have an actionStatus with an allowed value." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -41,10 +41,10 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
     ] .
 
 
-five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
+five-safes-crate:WorkflowexecutionObjectHasCompliantStartTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
+    sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
 
     sh:target [
         a sh:SPARQLTarget ;
@@ -55,12 +55,7 @@ five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
             SELECT ?this
             WHERE {
                 ?this rdf:type schema:CreateAction ;
-                      schema:actionStatus ?status .
-                FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus",
-                    "http://schema.org/ActiveActionStatus"
-                ))
+                      schema:startTime ?time .
             }
         """ ;
     ] ;
@@ -69,19 +64,17 @@ five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
         a sh:PropertyShape ;
         sh:name "StartTime" ;
         sh:path schema:startTime ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
-        sh:description "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
-        sh:message "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
+        sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+        sh:message "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
     ] .
 
     
-five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
+five-safes-crate:WorkflowexecutionObjectHasCompliantEndTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
+    sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
 
     sh:target [
         a sh:SPARQLTarget ;
@@ -92,11 +85,7 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
             SELECT ?this
             WHERE {
                 ?this rdf:type schema:CreateAction ;
-                      schema:actionStatus ?status .
-                FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus"
-                ))
+                      schema:endTime ?time .
             }
         """ ;
     ] ;
@@ -105,12 +94,10 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
         a sh:PropertyShape ;
         sh:name "EndTime" ;
         sh:path schema:endTime ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
-        sh:description "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
-        sh:message "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
+        sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+        sh:message "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
     ] .
 
 
@@ -122,7 +109,7 @@ five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
         a sh:PropertyShape ;
         sh:minCount 1 ;
         sh:name "actionStatus" ;
-        sh:description "WorkflowExecution MUST have an actionStatus with an allowed value." ;
+        sh:description "WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
         sh:path schema:actionStatus ;
         sh:in (
             "http://schema.org/PotentialActionStatus"
@@ -131,5 +118,5 @@ five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
             "http://schema.org/FailedActionStatus"
         ) ;
         sh:severity sh:Violation ;
-        sh:message "WorkflowExecution MUST have an actionStatus with an allowed value." ;
+        sh:message "WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -44,7 +44,7 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
 five-safes-crate:WorkflowexecutionObjectHasCompliantStartTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+    sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
 
     sh:target [
         a sh:SPARQLTarget ;
@@ -64,17 +64,16 @@ five-safes-crate:WorkflowexecutionObjectHasCompliantStartTimeFormat
         a sh:PropertyShape ;
         sh:name "StartTime" ;
         sh:path schema:startTime ;
-        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
-        sh:description "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
-        sh:message "The startTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+        sh:message "The startTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
     ] .
 
     
 five-safes-crate:WorkflowexecutionObjectHasCompliantEndTimeFormat
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+    sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
 
     sh:target [
         a sh:SPARQLTarget ;
@@ -94,10 +93,9 @@ five-safes-crate:WorkflowexecutionObjectHasCompliantEndTimeFormat
         a sh:PropertyShape ;
         sh:name "EndTime" ;
         sh:path schema:endTime ;
-        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|z|[+-][0-9]{2}:[0-9]{2})$" ;
         sh:severity sh:Violation ;
-        sh:description "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
-        sh:message "The endTime of the workflow execution object MUST follow the RFC 3339 standard." ;
+        sh:message "The endTime of the workflow execution object MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:WorkflowMustHaveDescriptiveName
+    a sh:NodeShape ;
+    sh:name "WorkflowExecution" ;
+    sh:targetClass schema:CreateAction ;
+
+    sh:property [
+        sh:a sh:PropertyShape ;
+        sh:name "name" ;
+        sh:minCount 1 ;    
+        sh:description "Workflow (CreateAction) MUST have a name string of at least 20 characters." ;
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:minLength 20 ;
+        sh:severity sh:Violation ;
+        sh:message "Workflow (CreateAction) MUST have a name string of at least 20 characters." ;
+    ] .
+
+
+five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
+    a sh:NodeShape ;
+    sh:name "WorkflowExecution" ;
+    sh:description "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+            SELECT ?this
+            WHERE {
+                ?this rdf:type schema:CreateAction ;
+                      schema:actionStatus ?status .
+                FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "StartTime" ;
+        sh:path schema:startTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:severity sh:Violation ;
+        sh:description "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
+        sh:message "The workflow execution object MUST have a startTime property with a valid datetime if it has begun." ;
+    ] .
+
+    
+five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
+    a sh:NodeShape ;
+    sh:name "WorkflowExecution" ;
+    sh:description "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX schema: <http://schema.org/>
+            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+            SELECT ?this
+            WHERE {
+                ?this rdf:type schema:CreateAction ;
+                      schema:actionStatus ?status .
+                FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+            }
+        """ ;
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "EndTime" ;
+        sh:path schema:endTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$" ;
+        sh:severity sh:Violation ;
+        sh:description "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
+        sh:message "The workflow execution object MUST have the endTime property with a valid datetime if it has ended." ;
+    ] .
+
+    

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -32,12 +32,12 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
         sh:a sh:PropertyShape ;
         sh:name "name" ;
         sh:minCount 1 ;    
-        sh:description "Workflow (CreateAction) MUST have a name string of at least 20 characters." ;
+        sh:description "Workflow (CreateAction) MUST have a name string of at least 10 characters." ;
         sh:path schema:name ;
         sh:datatype xsd:string ;
-        sh:minLength 20 ;
+        sh:minLength 10 ;
         sh:severity sh:Violation ;
-        sh:message "Workflow (CreateAction) MUST have a name string of at least 20 characters." ;
+        sh:message "Workflow (CreateAction) MUST have a name string of at least 10 characters." ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+
+five-safes-crate:RootDataEntityShouldMentionWorkflow 
+    a sh:NodeShape ;
+    sh:name "RootDataEntity" ;
+    sh:description "The RootDataEntity SHOULD mention a workflow execution object typed as CreateAction." ;
+    sh:targetClass ro-crate:RootDataEntity ;
+    sh:sparql [
+        a sh:SPARQLConstraint ; 
+        sh:name "mentions" ;
+        sh:select """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT $this 
+        WHERE {
+            
+            FILTER NOT EXISTS {
+                $this schema:mentions ?workflowExecution .
+                ?workflowExecution rdf:type schema:CreateAction .
+            }
+        }
+        """ ;
+      sh:severity sh:Warning ;
+      sh:message "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)." ;
+   ] .

--- a/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
@@ -106,7 +106,9 @@
         {
             "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
             "@type": "CreateAction",
-            "actionStatus": "http://schema.org/CompleteActionStatus",
+            "startTime": "2023-04-18T12:12:00+01:00",
+            "endTime": "2023-04-19T16:59:59+01:00",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
             "agent": {
                 "@id": "https://orcid.org/0000-0001-9842-9718"
             },
@@ -160,7 +162,7 @@
             "@type": "PropertyValue",
             "name": "tre72",
             "value": "project81"
-        },        
+        },
         {
             "@id": "input1.txt",
             "@type": "File",
@@ -303,6 +305,7 @@
                 "@id": "https://w3id.org/shp#DisclosureCheck"
             },
             "name": "Disclosure check of workflow results: approved",
+            "startTime": "2023-04-24T00:00:00+01:00",
             "endTime": "2023-04-25T16:00:00+01:00",
             "object": {
                 "@id": "./"

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -241,7 +241,7 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
         }
         WHERE {
             ?s rdf:type schema:CreateAction ;
-               schema:endTime ?time .    
+               schema:endTime ?time . 
         }
         """)
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -107,19 +107,14 @@ def test_5src_workflow_object_with_not_long_enough_name():
 def test_5src_workflow_object_has_no_properly_formatted_start_time():
     sparql = (SPARQL_PREFIXES + """
         DELETE {
-            ?s schema:startTime ?o .
+            ?s schema:startTime ?time .
         }
         INSERT {
             ?s schema:startTime "1st Dec '25 @ 10:00:00" .
         }
         WHERE {
             ?s rdf:type schema:CreateAction ;
-               schema:actionStatus ?status .
-               FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus",
-                    "http://schema.org/ActiveActionStatus"
-                ))
+               schema:startTime ?time .
         }
         """)
 
@@ -128,7 +123,9 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["The startTime of the workflow execution object MUST follow the RFC 3339 standard."],
+        expected_triggered_issues=[
+            "The startTime of the workflow execution object MUST follow the RFC 3339 standard."
+            ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -137,18 +134,14 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time():
 def test_5src_workflow_object_has_no_properly_formatted_end_time():
     sparql = (SPARQL_PREFIXES + """
         DELETE {
-            ?s schema:endTime ?o .
+            ?s schema:endTime ?time .
         }
         INSERT {
             ?s schema:endTime "1st Dec '25 @ 10:00:00" .
         }
         WHERE {
             ?s rdf:type schema:CreateAction ;
-               schema:actionStatus ?status .
-               FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus"
-                ))
+               schema:endTime ?time .
         }
         """)
 
@@ -157,7 +150,9 @@ def test_5src_workflow_object_has_no_properly_formatted_end_time():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["The endTime of the workflow execution object MUST follow the RFC 3339 standard."],
+        expected_triggered_issues=[
+            "The endTime of the workflow execution object MUST follow the RFC 3339 standard."
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -178,8 +173,11 @@ def test_5src_workflow_object_with_no_action_status():
         rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=[(
+            "WorkflowExecution MUST have an actionStatus "
+            "with an allowed value (see https://schema.org/ActionStatusType)."
+        )],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -204,7 +202,10 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)."],
+        expected_triggered_issues=[(
+            "WorkflowExecution MUST have an actionStatus "
+            "with an allowed value (see https://schema.org/ActionStatusType)."
+        )],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -228,7 +229,9 @@ def test_5src_workflow_object_not_mentioned_by_root_data_entity():
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
-        expected_triggered_issues=["RootDataEntity SHOULD mention workflow execution object (typed CreateAction)."],
+        expected_triggered_issues=[
+            "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)."
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -250,7 +253,9 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["The workflow execution object SHOULD have an endTime property if it has ended."],
+        expected_triggered_issues=[
+            "The workflow execution object SHOULD have an endTime property if it has ended."
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -274,7 +279,9 @@ def test_5src_workflow_object_has_no_start_time_if_begun():
         requirement_severity=Severity.OPTIONAL,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["The workflow execution object MAY have a startTime if execution was initiated."],
+        expected_triggered_issues=[
+            "The workflow execution object MAY have a startTime if execution was initiated."
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -256,7 +256,7 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
     )
 
 
-#------- MAY fail tests
+# ------- MAY fail tests
 
 def test_5src_workflow_object_has_no_start_time_if_begun():
     sparql = (SPARQL_PREFIXES + """

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -44,7 +44,7 @@ def test_5src_workflow_object_with_no_name():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 10 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -70,7 +70,7 @@ def test_5src_workflow_object_with_name_not_string():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 10 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -82,7 +82,7 @@ def test_5src_workflow_object_with_not_long_enough_name():
             ?this schema:name ?name .
         }
         INSERT {
-            ?this schema:name "Too short" .
+            ?this schema:name "Short" .
         }
         WHERE {
             ?this rdf:type schema:CreateAction ;
@@ -96,7 +96,7 @@ def test_5src_workflow_object_with_not_long_enough_name():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 10 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -241,7 +241,7 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
         }
         WHERE {
             ?s rdf:type schema:CreateAction ;
-               schema:endTime ?time . 
+               schema:endTime ?time .
         }
         """)
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -121,9 +121,10 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=[
-            "The startTime of the workflow execution object MUST follow the RFC 3339 standard."
-            ],
+        expected_triggered_issues=[(
+            "The startTime of the workflow execution object MUST follow the RFC 3339 standard. "
+            "(YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))."
+        )],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -148,9 +149,10 @@ def test_5src_workflow_object_has_no_properly_formatted_end_time():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
-        expected_triggered_issues=[
-            "The endTime of the workflow execution object MUST follow the RFC 3339 standard."
-        ],
+        expected_triggered_issues=[(
+            "The endTime of the workflow execution object MUST follow the RFC 3339 standard. "
+            "(YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))."
+        )],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -22,8 +22,6 @@ from tests.shared import do_entity_test, SPARQL_PREFIXES
 logger = logging.getLogger(__name__)
 
 
-
-
 # ----- MUST fails tests
 
 
@@ -262,6 +260,7 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
 
 
 # ------- MAY fail tests
+
 
 def test_5src_workflow_object_has_no_start_time_if_begun():
     sparql = (SPARQL_PREFIXES + """

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -234,6 +234,59 @@ def test_5src_workflow_object_has_no_properly_formatted_end_time_if_ended():
     )
 
 
+def test_5src_workflow_object_with_no_action_status():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:actionStatus ?o .
+        }
+        WHERE {
+            ?this schema:actionStatus ?o ;
+                  rdf:type schema:CreateAction .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_with_no_properly_valued_action_status():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:actionStatus ?o .
+        }
+        INSERT {
+            ?this schema:actionStatus "Not a proper actionStatus value" .
+        }
+        WHERE {
+            ?this schema:actionStatus ?o ;
+                  rdf:type schema:CreateAction .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
 # ----- SHOULD fails tests
 
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- MUST fails tests
+
+
+def test_5src_workflow_object_with_no_name():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        WHERE {
+            ?this rdf:type schema:CreateAction ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_with_name_not_string():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        INSERT {
+            ?this schema:name 123 .
+        }
+        WHERE {
+            ?this rdf:type schema:CreateAction ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_with_not_long_enough_name():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?this schema:name ?name .
+        }
+        INSERT {
+            ?this schema:name "Too short" .
+        }
+        WHERE {
+            ?this rdf:type schema:CreateAction ;
+                  schema:name ?name .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_has_no_start_time_if_begun():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?s schema:startTime ?o .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_has_no_properly_formatted_start_time_if_begun():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?s schema:startTime ?o .
+        }
+        INSERT {
+            ?s schema:startTime "1st Dec '25 @ 10:00:00" .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus",
+                    "http://schema.org/ActiveActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_has_no_end_time_if_ended():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX shp:    <https://w3id.org/shp#>        
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?s schema:endTime ?o .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_has_no_properly_formatted_end_time_if_ended():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            ?s schema:endTime ?o .
+        }
+        INSERT {
+            ?s schema:endTime "1st Dec '25 @ 10:00:00" .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction ;
+               schema:actionStatus ?status .
+               FILTER(?status IN (
+                    "http://schema.org/CompletedActionStatus",
+                    "http://schema.org/FailedActionStatus"
+                ))
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+# ----- SHOULD fails tests
+
+
+def test_5src_workflow_object_not_mentioned_by_root_data_entity():
+    sparql = """
+        PREFIX schema: <http://schema.org/>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        DELETE {
+            <./> schema:mentions ?o .
+        }
+        WHERE {
+            ?o rdf:type schema:CreateAction .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=None,
+        expected_triggered_issues=None,
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -122,7 +122,7 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[(
-            "The startTime of the workflow execution object MUST follow the RFC 3339 standard. "
+            "The startTime of the workflow execution object MUST follow the RFC 3339 standard "
             "(YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))."
         )],
         profile_identifier="five-safes-crate",
@@ -150,7 +150,7 @@ def test_5src_workflow_object_has_no_properly_formatted_end_time():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[(
-            "The endTime of the workflow execution object MUST follow the RFC 3339 standard. "
+            "The endTime of the workflow execution object MUST follow the RFC 3339 standard "
             "(YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))."
         )],
         profile_identifier="five-safes-crate",

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -16,46 +16,44 @@ import logging
 
 from rocrate_validator.models import Severity
 from tests.ro_crates import ValidROC
-from tests.shared import do_entity_test
+from tests.shared import do_entity_test, SPARQL_PREFIXES
 
 # set up logging
 logger = logging.getLogger(__name__)
+
+
 
 
 # ----- MUST fails tests
 
 
 def test_5src_workflow_object_with_no_name():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
+    sparql = (
+        SPARQL_PREFIXES + """
         DELETE {
             ?this schema:name ?name .
         }
         WHERE {
             ?this rdf:type schema:CreateAction ;
-                  schema:name ?name .
+                    schema:name ?name .
             <./> schema:mentions ?this .
         }
-        """
+    """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
 
 
 def test_5src_workflow_object_with_name_not_string():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?this schema:name ?name .
         }
@@ -67,24 +65,21 @@ def test_5src_workflow_object_with_name_not_string():
                   schema:name ?name .
             <./> schema:mentions ?this .
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
 
 
 def test_5src_workflow_object_with_not_long_enough_name():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?this schema:name ?name .
         }
@@ -96,54 +91,21 @@ def test_5src_workflow_object_with_not_long_enough_name():
                   schema:name ?name .
             <./> schema:mentions ?this .
         }
-        """
+    """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["Workflow (CreateAction) MUST have a name string of at least 20 characters."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
 
 
-def test_5src_workflow_object_has_no_start_time_if_begun():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-        DELETE {
-            ?s schema:startTime ?o .
-        }
-        WHERE {
-            ?s rdf:type schema:CreateAction;
-               schema:actionStatus ?status .
-               FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus",
-                    "http://schema.org/ActiveActionStatus"
-                ))
-        }
-        """
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.REQUIRED,
-        expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_5src_workflow_object_has_no_properly_formatted_start_time_if_begun():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+def test_5src_workflow_object_has_no_properly_formatted_start_time():
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?s schema:startTime ?o .
         }
@@ -159,54 +121,21 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time_if_begun():
                     "http://schema.org/ActiveActionStatus"
                 ))
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["The startTime of the workflow execution object MUST follow the RFC 3339 standard."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
 
 
-def test_5src_workflow_object_has_no_end_time_if_ended():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX shp:    <https://w3id.org/shp#>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-        DELETE {
-            ?s schema:endTime ?o .
-        }
-        WHERE {
-            ?s rdf:type schema:CreateAction ;
-               schema:actionStatus ?status .
-               FILTER(?status IN (
-                    "http://schema.org/CompletedActionStatus",
-                    "http://schema.org/FailedActionStatus"
-                ))
-        }
-        """
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.REQUIRED,
-        expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_5src_workflow_object_has_no_properly_formatted_end_time_if_ended():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+def test_5src_workflow_object_has_no_properly_formatted_end_time():
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?s schema:endTime ?o .
         }
@@ -221,24 +150,21 @@ def test_5src_workflow_object_has_no_properly_formatted_end_time_if_ended():
                     "http://schema.org/FailedActionStatus"
                 ))
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["The endTime of the workflow execution object MUST follow the RFC 3339 standard."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
 
 
 def test_5src_workflow_object_with_no_action_status():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?this schema:actionStatus ?o .
         }
@@ -246,10 +172,10 @@ def test_5src_workflow_object_with_no_action_status():
             ?this schema:actionStatus ?o ;
                   rdf:type schema:CreateAction .
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=None,
@@ -260,10 +186,7 @@ def test_5src_workflow_object_with_no_action_status():
 
 
 def test_5src_workflow_object_with_no_properly_valued_action_status():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             ?this schema:actionStatus ?o .
         }
@@ -274,14 +197,14 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
             ?this schema:actionStatus ?o ;
                   rdf:type schema:CreateAction .
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
@@ -291,24 +214,67 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
 
 
 def test_5src_workflow_object_not_mentioned_by_root_data_entity():
-    sparql = """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
+    sparql = (SPARQL_PREFIXES + """
         DELETE {
             <./> schema:mentions ?o .
         }
         WHERE {
             ?o rdf:type schema:CreateAction .
         }
-        """
+        """)
 
     do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
+        rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=None,
-        expected_triggered_issues=None,
+        expected_triggered_requirements=["RootDataEntity"],
+        expected_triggered_issues=["RootDataEntity SHOULD mention workflow execution object (typed CreateAction)."],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+def test_5src_workflow_object_has_no_end_time_if_ended():
+    sparql = (SPARQL_PREFIXES + """
+        DELETE {
+            ?s schema:endTime ?time .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction ;
+               schema:endTime ?time .       
+        }
+        """)
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_result,
+        requirement_severity=Severity.RECOMMENDED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["The workflow execution object SHOULD have an endTime property if it has ended."],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+
+#------- MAY fail tests
+
+def test_5src_workflow_object_has_no_start_time_if_begun():
+    sparql = (SPARQL_PREFIXES + """
+        DELETE {
+            ?s schema:startTime ?time .
+        }
+        WHERE {
+            ?s rdf:type schema:CreateAction;
+               schema:startTime ?time
+        }
+        """)
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_result,
+        requirement_severity=Severity.OPTIONAL,
+        expected_validation_result=False,
+        expected_triggered_requirements=["WorkflowExecution"],
+        expected_triggered_issues=["The workflow execution object MAY have a startTime if execution was initiated."],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -241,7 +241,7 @@ def test_5src_workflow_object_has_no_end_time_if_ended():
         }
         WHERE {
             ?s rdf:type schema:CreateAction ;
-               schema:endTime ?time .       
+               schema:endTime ?time .    
         }
         """)
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -175,7 +175,7 @@ def test_5src_workflow_object_has_no_properly_formatted_start_time_if_begun():
 def test_5src_workflow_object_has_no_end_time_if_ended():
     sparql = """
         PREFIX schema: <http://schema.org/>
-        PREFIX shp:    <https://w3id.org/shp#>        
+        PREFIX shp:    <https://w3id.org/shp#>
         PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
         DELETE {

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -34,7 +34,10 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-SPARQL_PREFIXES = """PREFIX schema: <http://schema.org/>
+SPARQL_PREFIXES = """
+PREFIX schema: <http://schema.org/>
+PREFIX shp:    <https://w3id.org/shp#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 """
 
 


### PR DESCRIPTION
This PR addresses #37 

## Rules implemented

| # | Description | sh:Severity |
|---|--------------|-------------|
| 1 | RootDataEntity SHOULD mention a Workflow Execution object (i) | sh:Warning |
| 2 | The Workflow Execution object MUST provide a human-readable name (ii) | sh:Violation |
| 3 | Workflow Execution object MUST be of type CreateAction (iii) | sh:Violation |
| 4 | The Workflow Execution object MAY have the startTime property if it has begun. | sh:Info |
| 5 | The startTime of the workflow execution object MUST follow the RFC 3339 standard. | sh:Violation |
| 5 | The Workflow Execution object SHOULD  have the endTime property if it has ended. | sh:Warning |
| 6 | The endTime of the workflow execution object MUST follow the RFC 3339 standard. | sh:Violation |
| 7 | The endTime of the workflow execution object MUST follow the RFC 3339 standard. | sh:Violation |
| 8 | The Workflow Execution object MUST have an actionStatus that reflects the current execution state. | sh:Violation |

(i) The Workflow Execution object is the only entity in this phase that is typed `schema:CreateAction`.
(ii) This was implemented by requiring that the name of the Workflow Execution object is of type string and is at least 10 characters long. 
(iii) This rule is implemented implicitly within the others. For example the RootDataEntity MUST mention a CreateAction entity which is assumed to be the Workflow Execution object in this phase (there is only one CreateAction object in the crate's graph).