### PR TITLE
Implement Metadata File expectations

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
 import re
 
 import rocrate_validator.log as logging
 from rocrate_validator.models import Severity, ValidationContext
-from rocrate_validator.requirements.python import (PyFunctionCheck, check,
-                                                   requirement)
-from rocrate_validator.utils import HttpRequester
+from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -32,23 +29,32 @@ class FileDescriptorExistence(PyFunctionCheck):
     @check(name="RO-Crate context version", severity=Severity.REQUIRED)
     def test_existence(self, context: ValidationContext) -> bool:
         """
-        The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`
+        The RO-Crate metadata file MUST include the RO-Crate context version 1.2
+        (or later minor version) in `@context`
         """
         try:
             json_dict = context.ro_crate.metadata.as_dict()
             context_value = json_dict["@context"]
-            pattern = re.compile(r"https://w3id\.org/ro/crate/1\.[2-9](-DRAFT)?/context")
+            pattern = re.compile(
+                r"https://w3id\.org/ro/crate/1\.[2-9](-DRAFT)?/context"
+            )
             passed = True
             if isinstance(context_value, list):
-                if not any(pattern.match(item) for item in context_value if isinstance(item, str)):
+                if not any(
+                    pattern.match(item)
+                    for item in context_value
+                    if isinstance(item, str)
+                ):
                     passed = False
             else:
                 if not pattern.match(context_value):
                     passed = False
             if not passed:
                 context.result.add_issue(
-                    f"The RO-Crate metadata file MUST include the RO-Crate context "
-                    "version 1.2 (or later minor version) in `@context`", self)
+                    "The RO-Crate metadata file MUST include the RO-Crate context "
+                    "version 1.2 (or later minor version) in `@context`",
+                    self,
+                )
             return passed
 
         except Exception as e:

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 @requirement(name="RO-Crate context version")
 class FileDescriptorExistence(PyFunctionCheck):
-    """The RO-Crate metadata file MUST include the RO-Crate context version 1.2 
+    """The RO-Crate metadata file MUST include the RO-Crate context version 1.2
     (or later minor version) in `@context`"""
 
     @check(name="RO-Crate context version", severity=Severity.REQUIRED)

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 
 @requirement(name="RO-Crate context version")
 class FileDescriptorExistence(PyFunctionCheck):
-    """The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"""
+    """The RO-Crate metadata file MUST include the RO-Crate context version 1.2 
+    (or later minor version) in `@context`"""
 
     @check(name="RO-Crate context version", severity=Severity.REQUIRED)
     def test_existence(self, context: ValidationContext) -> bool:

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+import re
+
+import rocrate_validator.log as logging
+from rocrate_validator.models import Severity, ValidationContext
+from rocrate_validator.requirements.python import (PyFunctionCheck, check,
+                                                   requirement)
+from rocrate_validator.utils import HttpRequester
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+@requirement(name="RO-Crate context version")
+class FileDescriptorExistence(PyFunctionCheck):
+    """The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"""
+
+    @check(name="RO-Crate context version", severity=Severity.REQUIRED)
+    def test_existence(self, context: ValidationContext) -> bool:
+        """
+        The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`
+        """
+        try:
+            json_dict = context.ro_crate.metadata.as_dict()
+            context_value = json_dict["@context"]
+            pattern = re.compile(r"https://w3id\.org/ro/crate/1\.[2-9](-DRAFT)?/context")
+            passed = True
+            if isinstance(context_value, list):
+                if not any(pattern.match(item) for item in context_value if isinstance(item, str)):
+                    passed = False
+            else:
+                if not pattern.match(context_value):
+                    passed = False
+            if not passed:
+                context.result.add_issue(
+                    f"The RO-Crate metadata file MUST include the RO-Crate context "
+                    "version 1.2 (or later minor version) in `@context`", self)
+            return passed
+
+        except Exception as e:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.exception(e)
+        return True

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @requirement(name="RO-Crate context version")
-class FileDescriptorExistence(PyFunctionCheck):
+class FileDescriptorContextVersion(PyFunctionCheck):
     """The RO-Crate metadata file MUST include the RO-Crate context version 1.2
     (or later minor version) in `@context`"""
 

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.ttl
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+five-safes-crate:MetadataFileDescriptorProperties a sh:NodeShape ;
+    sh:name "RO-Crate conforms to 1.2 or later minor version" ;
+    sh:description """The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version""";
+    sh:targetClass ro-crate:ROCrateMetadataFileDescriptor ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "RO-Crate conforms to 1.2 or later minor version" ;
+        sh:description "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version" ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:conformsTo ;
+        sh:pattern "https://w3id\\.org/ro/crate/(1\\.[2-9](-DRAFT)?)" ;
+        sh:severity sh:Violation;
+        sh:message "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version" ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/15_metadata_file.ttl
@@ -37,3 +37,5 @@ five-safes-crate:MetadataFileDescriptorProperties a sh:NodeShape ;
         sh:severity sh:Violation;
         sh:message "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version" ;
     ] .
+
+ro-crate:conformsToROCrateSpec sh:deactivated true .

--- a/rocrate_validator/profiles/ro-crate/must/1_file-descriptor_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/1_file-descriptor_metadata.ttl
@@ -89,13 +89,12 @@ ro-crate:ROCrateMetadataFileDescriptorRecommendedProperties a sh:NodeShape ;
         sh:class schema_org:Dataset ;
         sh:message "The RO-Crate metadata file descriptor MUST have an `about` property referencing the Root Data Entity" ;
     ] ;
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "Metadata File Descriptor entity: `conformsTo` property" ;
-        sh:description """Check if the RO-Crate Metadata File Descriptor has a `conformsTo` property which points to the RO-Crate specification version""" ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:conformsTo ;
-        sh:hasValue <https://w3id.org/ro/crate/1.1> ;
-        sh:message "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with the RO-Crate specification version" ;
-    ] .
+    sh:property ro-crate:conformsToROCrateSpec .
+
+ro-crate:conformsToROCrateSpec sh:name "Metadata File Descriptor entity: `conformsTo` property" ;
+    sh:description """Check if the RO-Crate Metadata File Descriptor has a `conformsTo` property which points to the RO-Crate specification version""" ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:path dct:conformsTo ;
+    sh:hasValue <https://w3id.org/ro/crate/1.1> ;
+    sh:message "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with the RO-Crate specification version" .

--- a/tests/data/crates/invalid/five_safes_crate/context_multiple_wrong_version/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/five_safes_crate/context_multiple_wrong_version/ro-crate-metadata.json
@@ -1,0 +1,169 @@
+{
+    "@context": ["https://w3id.org/ro/crate/1.1/context", "http://schema.org", {"test": "http://schema.org/test"}],
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.2"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "5-Safe RO-Crate Request",
+            "description": "example 5-Safe RO-Crate request metadata for testing",
+            "license": "Apache-2.0",
+            "datePublished": "2025-09-20T14:38:00+00:00",
+            "conformsTo": {
+                "@id": "https://w3id.org/5s-crate/0.4"
+            },
+            "hasPart": [
+                {
+                    "@id": "https://workflowhub.eu/workflows/289?version=1"
+                },
+                {
+                    "@id": "input1.txt"
+                }
+            ],
+            "mainEntity": {
+                "@id": "https://workflowhub.eu/workflows/289?version=1"
+            },
+            "mentions": {
+                "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538"
+            },
+            "sourceOrganization": {
+                "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70"
+            }
+        },
+        {
+            "@id": "https://w3id.org/5s-crate/0.4",
+            "@type": "Profile",
+            "name": "Five Safes RO-Crate profile"
+        },
+        {
+            "@id": "https://workflowhub.eu/workflows/289?version=1",
+            "@type": "Dataset",
+            "name": "CWL Protein MD Setup tutorial with mutations",
+            "conformsTo": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+            },
+            "distribution": {
+                "@id": "https://workflowhub.eu/workflows/289/ro_crate?version=1"
+            }
+        },
+        {
+            "@id": "https://workflowhub.eu/workflows/289/ro_crate?version=1",
+            "@type": "DataDownload",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate"
+            },
+            "encodingFormat": "application/zip"
+        },
+        {
+            "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
+            "@type": "CreateAction",
+            "actionStatus": "http://schema.org/PotentialActionStatus",
+            "agent": {
+                "@id": "https://orcid.org/0000-0001-9842-9718"
+            },
+            "instrument": {
+                "@id": "https://workflowhub.eu/workflows/289?version=1"
+            },
+            "name": "Execute query 12389 on workflow ",
+            "object": [
+                {
+                    "@id": "input1.txt"
+                },
+                {
+                    "@id": "#enableFastMode"
+                }
+            ]
+        },
+        {
+            "@id": "https://orcid.org/0000-0001-9842-9718",
+            "@type": "Person",
+            "name": "Stian Soiland-Reyes",
+            "affiliation": {
+                "@id": "https://ror.org/027m9bs27"
+            },
+            "memberOf": [
+                {
+                    "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70"
+                }
+            ]
+        },
+        {
+            "@id": "https://ror.org/027m9bs27",
+            "@type": "Organization",
+            "name": "The University of Manchester"
+        },
+        {
+            "@id": "https://ror.org/01ee9ar58",
+            "@type": "Organization",
+            "name": "University of Nottingham"
+        },
+        {
+            "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70",
+            "@type": "Project",
+            "name": "Investigation of cancer (TRE72 project 81)",
+            "identifier": [
+                {
+                    "@id": "_:localid:tre72:project81"
+                }
+            ],
+            "funding": {
+                "@id": "https://gtr.ukri.org/projects?ref=10038961"
+            },
+            "member": [
+                {
+                    "@id": "https://ror.org/027m9bs27"
+                },
+                {
+                    "@id": "https://ror.org/01ee9ar58"
+                }
+            ]
+        },
+        {
+            "@id": "_:localid:tre72:project81",
+            "@type": "PropertyValue",
+            "name": "tre72",
+            "value": "project81"
+        },
+        {
+            "@id": "https://gtr.ukri.org/projects?ref=10038961",
+            "@type": "Grant",
+            "name": "EOSC4Cancer"
+        },
+        {
+            "@id": "input1.txt",
+            "@type": "File",
+            "name": "input1",
+            "exampleOfWork": {
+                "@id": "#sequence"
+            }
+        },
+        {
+            "@id": "#enableFastMode",
+            "@type": "PropertyValue",
+            "name": "--fast-mode",
+            "value": "True",
+            "exampleOfWork": {
+                "@id": "#fast"
+            }
+        },
+        {
+            "@id": "#sequence",
+            "@type": "FormalParameter",
+            "name": "input-sequence"
+        },
+        {
+            "@id": "#fast",
+            "@type": "FormalParameter",
+            "name": "fast-mode"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/five_safes_crate/context_single_wrong_version/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/five_safes_crate/context_single_wrong_version/ro-crate-metadata.json
@@ -1,0 +1,169 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.2"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "5-Safe RO-Crate Request",
+            "description": "example 5-Safe RO-Crate request metadata for testing",
+            "license": "Apache-2.0",
+            "datePublished": "2025-09-20T14:38:00+00:00",
+            "conformsTo": {
+                "@id": "https://w3id.org/5s-crate/0.4"
+            },
+            "hasPart": [
+                {
+                    "@id": "https://workflowhub.eu/workflows/289?version=1"
+                },
+                {
+                    "@id": "input1.txt"
+                }
+            ],
+            "mainEntity": {
+                "@id": "https://workflowhub.eu/workflows/289?version=1"
+            },
+            "mentions": {
+                "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538"
+            },
+            "sourceOrganization": {
+                "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70"
+            }
+        },
+        {
+            "@id": "https://w3id.org/5s-crate/0.4",
+            "@type": "Profile",
+            "name": "Five Safes RO-Crate profile"
+        },
+        {
+            "@id": "https://workflowhub.eu/workflows/289?version=1",
+            "@type": "Dataset",
+            "name": "CWL Protein MD Setup tutorial with mutations",
+            "conformsTo": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+            },
+            "distribution": {
+                "@id": "https://workflowhub.eu/workflows/289/ro_crate?version=1"
+            }
+        },
+        {
+            "@id": "https://workflowhub.eu/workflows/289/ro_crate?version=1",
+            "@type": "DataDownload",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate"
+            },
+            "encodingFormat": "application/zip"
+        },
+        {
+            "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
+            "@type": "CreateAction",
+            "actionStatus": "http://schema.org/PotentialActionStatus",
+            "agent": {
+                "@id": "https://orcid.org/0000-0001-9842-9718"
+            },
+            "instrument": {
+                "@id": "https://workflowhub.eu/workflows/289?version=1"
+            },
+            "name": "Execute query 12389 on workflow ",
+            "object": [
+                {
+                    "@id": "input1.txt"
+                },
+                {
+                    "@id": "#enableFastMode"
+                }
+            ]
+        },
+        {
+            "@id": "https://orcid.org/0000-0001-9842-9718",
+            "@type": "Person",
+            "name": "Stian Soiland-Reyes",
+            "affiliation": {
+                "@id": "https://ror.org/027m9bs27"
+            },
+            "memberOf": [
+                {
+                    "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70"
+                }
+            ]
+        },
+        {
+            "@id": "https://ror.org/027m9bs27",
+            "@type": "Organization",
+            "name": "The University of Manchester"
+        },
+        {
+            "@id": "https://ror.org/01ee9ar58",
+            "@type": "Organization",
+            "name": "University of Nottingham"
+        },
+        {
+            "@id": "#project-be6ffb55-4f5a-4c14-b60e-47e0951090c70",
+            "@type": "Project",
+            "name": "Investigation of cancer (TRE72 project 81)",
+            "identifier": [
+                {
+                    "@id": "_:localid:tre72:project81"
+                }
+            ],
+            "funding": {
+                "@id": "https://gtr.ukri.org/projects?ref=10038961"
+            },
+            "member": [
+                {
+                    "@id": "https://ror.org/027m9bs27"
+                },
+                {
+                    "@id": "https://ror.org/01ee9ar58"
+                }
+            ]
+        },
+        {
+            "@id": "_:localid:tre72:project81",
+            "@type": "PropertyValue",
+            "name": "tre72",
+            "value": "project81"
+        },
+        {
+            "@id": "https://gtr.ukri.org/projects?ref=10038961",
+            "@type": "Grant",
+            "name": "EOSC4Cancer"
+        },
+        {
+            "@id": "input1.txt",
+            "@type": "File",
+            "name": "input1",
+            "exampleOfWork": {
+                "@id": "#sequence"
+            }
+        },
+        {
+            "@id": "#enableFastMode",
+            "@type": "PropertyValue",
+            "name": "--fast-mode",
+            "value": "True",
+            "exampleOfWork": {
+                "@id": "#fast"
+            }
+        },
+        {
+            "@id": "#sequence",
+            "@type": "FormalParameter",
+            "name": "input-sequence"
+        },
+        {
+            "@id": "#fast",
+            "@type": "FormalParameter",
+            "name": "fast-mode"
+        }
+    ]
+}

--- a/tests/data/crates/valid/five-safes-crate-multiple-context/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-multiple-context/ro-crate-metadata.json
@@ -1,5 +1,5 @@
 {
-    "@context": ["https://w3id.org/ro/crate/1.2/context", "http://schema.org", {"test": "http://schema.org/test"}],
+    "@context": ["https://w3id.org/ro/crate/1.2/context", "https://w3id.org/ro/terms/workflow-run/context", {"test": "http://schema.org/test"}],
     "@graph": [
         {
             "@type": "CreativeWork",

--- a/tests/data/crates/valid/five-safes-crate-multiple-context/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-multiple-context/ro-crate-metadata.json
@@ -1,5 +1,5 @@
 {
-    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@context": ["https://w3id.org/ro/crate/1.2/context", "http://schema.org", {"test": "http://schema.org/test"}],
     "@graph": [
         {
             "@type": "CreativeWork",

--- a/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
+++ b/tests/data/crates/valid/five-safes-crate-result/ro-crate-metadata.json
@@ -1,5 +1,5 @@
 {
-    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@context": "https://w3id.org/ro/crate/1.2/context",
     "@graph": [
         {
             "@type": "CreativeWork",
@@ -8,7 +8,7 @@
                 "@id": "./"
             },
             "conformsTo": {
-                "@id": "https://w3id.org/ro/crate/1.1"
+                "@id": "https://w3id.org/ro/crate/1.2"
             }
         },
         {

--- a/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
@@ -28,13 +28,14 @@ logger = logging.getLogger(__name__)
 def test_5src_conforms_to_old_version():
     sparql = SPARQL_PREFIXES + """
         DELETE {
-            <ro-crate-metadata.json> dct:conformsTo ?version .
+            ?this dct:conformsTo ?version .
         }
         INSERT {
-            <ro-crate-metadata.json> dct:conformsTo <https://w3id.org/ro/crate/1.1> .
+            ?this dct:conformsTo <https://w3id.org/ro/crate/1.1> .
         }
         WHERE {
-            <ro-crate-metadata.json> dct:conformsTo ?version .
+            ?this dct:conformsTo ?version ;
+                schema:about <./> .
         }
         """
 

--- a/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC, Invalid5sROC
+from tests.shared import do_entity_test, SPARQL_PREFIXES
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- MUST fails tests
+
+
+def test_5src_conforms_to_old_version():
+    sparql = SPARQL_PREFIXES + """
+        DELETE {
+            <ro-crate-metadata.json> dct:conformsTo ?version .
+        }
+        INSERT {
+            <ro-crate-metadata.json> dct:conformsTo <https://w3id.org/ro/crate/1.1> .
+        }
+        WHERE {
+            <ro-crate-metadata.json> dct:conformsTo ?version .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_request,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RO-Crate conforms to 1.2 or later minor version"],
+        expected_triggered_issues=["The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version"],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )
+
+def test_5src_context_single_wrong_version():
+    do_entity_test(
+        rocrate_path=Invalid5sROC().context_single_wrong_version,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RO-Crate context version"],
+        expected_triggered_issues=["The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"],
+        profile_identifier="five-safes-crate",
+    )
+
+def test_5src_context_multiple_wrong_version():
+    do_entity_test(
+        rocrate_path=Invalid5sROC().context_multiple_wrong_version,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["RO-Crate context version"],
+        expected_triggered_issues=["The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"],
+        profile_identifier="five-safes-crate",
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 
 
 def test_5src_conforms_to_old_version():
-    sparql = SPARQL_PREFIXES + """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
         DELETE {
             ?this dct:conformsTo ?version .
         }
@@ -38,16 +40,23 @@ def test_5src_conforms_to_old_version():
                 schema:about <./> .
         }
         """
+    )
 
     do_entity_test(
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=["RO-Crate conforms to 1.2 or later minor version"],
-        expected_triggered_issues=["The RO-Crate metadata file descriptor MUST have a `conformsTo` property with RO-Crate specification version 1.2 or later minor version"],
+        expected_triggered_requirements=[
+            "RO-Crate conforms to 1.2 or later minor version"
+        ],
+        expected_triggered_issues=[
+            "The RO-Crate metadata file descriptor MUST have a `conformsTo` property with "
+            "RO-Crate specification version 1.2 or later minor version"
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )
+
 
 def test_5src_context_single_wrong_version():
     do_entity_test(
@@ -55,9 +64,13 @@ def test_5src_context_single_wrong_version():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["RO-Crate context version"],
-        expected_triggered_issues=["The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"],
+        expected_triggered_issues=[
+            "The RO-Crate metadata file MUST include the RO-Crate context version 1.2 "
+            "(or later minor version) in `@context`"
+        ],
         profile_identifier="five-safes-crate",
     )
+
 
 def test_5src_context_multiple_wrong_version():
     do_entity_test(
@@ -65,6 +78,9 @@ def test_5src_context_multiple_wrong_version():
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
         expected_triggered_requirements=["RO-Crate context version"],
-        expected_triggered_issues=["The RO-Crate metadata file MUST include the RO-Crate context version 1.2 (or later minor version) in `@context`"],
+        expected_triggered_issues=[
+            "The RO-Crate metadata file MUST include the RO-Crate context version 1.2 "
+            "(or later minor version) in `@context`"
+        ],
         profile_identifier="five-safes-crate",
     )

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -25,26 +25,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
-def skip_spec_version_identifier():
-    """Returns identifiers for RO-Crate version checks in the base RO-Crate profile.
-
-    Used to skip version checks while there is not a base profile available for RO-Crate 1.2 (only 1.1)
-    """
-    rocrate_profile = services.get_profile("ro-crate")
-    if not rocrate_profile:
-        raise RuntimeError("Unable to load the RO-Crate profile")
-    check_conformsTo_version = rocrate_profile.get_requirement_check(
-        "Metadata File Descriptor entity: `conformsTo` property"
-    )
-    assert (
-        check_conformsTo_version
-    ), 'Unable to find the requirement "Metadata File Descriptor entity: `conformsTo` property"'
-    SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER = check_conformsTo_version.identifier
-    return SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER
-
-
-def test_valid_five_safes_crate_request_required(skip_spec_version_identifier):
+def test_valid_five_safes_crate_request_required():
     """Test a valid Five Safes Crate representing a request."""
     do_entity_test(
         ValidROC().five_safes_crate_request,
@@ -53,14 +34,11 @@ def test_valid_five_safes_crate_request_required(skip_spec_version_identifier):
         profile_identifier="five-safes-crate",
         skip_checks=[
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
-            skip_spec_version_identifier,
         ],
-        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
-        disable_inherited_profiles_reporting=True,
     )
 
 
-def test_valid_five_safes_crate_result_required(skip_spec_version_identifier):
+def test_valid_five_safes_crate_result_required():
     """Test a valid Five Safes Crate representing a result."""
     do_entity_test(
         ValidROC().five_safes_crate_result,
@@ -69,14 +47,11 @@ def test_valid_five_safes_crate_result_required(skip_spec_version_identifier):
         profile_identifier="five-safes-crate",
         skip_checks=[
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
-            skip_spec_version_identifier,
         ],
-        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
-        disable_inherited_profiles_reporting=True,
     )
 
 
-def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
+def test_valid_five_safes_crate_multiple_context():
     """Test a valid Five Safes Crate representing a result."""
     do_entity_test(
         ValidROC().five_safes_crate_multiple_context,
@@ -85,8 +60,5 @@ def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
         profile_identifier="five-safes-crate",
         skip_checks=[
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
-            skip_spec_version_identifier,
         ],
-        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
-        disable_inherited_profiles_reporting=True,
     )

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import logging
-import pytest
 
-from rocrate_validator import services
 from rocrate_validator.models import Severity
 from tests.conftest import SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER
 from tests.ro_crates import ValidROC

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -37,7 +37,7 @@ def skip_spec_version_identifier():
     check_conformsTo_version = \
         rocrate_profile.get_requirement_check("Metadata File Descriptor entity: `conformsTo` property")
     assert check_conformsTo_version, \
-        "Metadata File Descriptor entity: `conformsTo` property"
+        'Unable to find the requirement "Metadata File Descriptor entity: `conformsTo` property"'
     SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER = check_conformsTo_version.identifier
     return SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER
 

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
+import pytest
 
+from rocrate_validator import services
 from rocrate_validator.models import Severity
 from tests.conftest import SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER
 from tests.ro_crates import ValidROC
@@ -23,23 +25,50 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def test_valid_five_safes_crate_request_required():
+@pytest.fixture
+def skip_spec_version_identifier():
+    """Returns identifiers for RO-Crate version checks in the base RO-Crate profile.
+
+    Used to skip version checks while there is not a base profile available for RO-Crate 1.2 (only 1.1)
+    """
+    rocrate_profile = services.get_profile("ro-crate")
+    if not rocrate_profile:
+        raise RuntimeError("Unable to load the RO-Crate profile")
+    check_conformsTo_version = \
+        rocrate_profile.get_requirement_check("Metadata File Descriptor entity: `conformsTo` property")
+    assert check_conformsTo_version, \
+        "Metadata File Descriptor entity: `conformsTo` property"
+    SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER = check_conformsTo_version.identifier
+    return SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER
+
+
+def test_valid_five_safes_crate_request_required(skip_spec_version_identifier):
     """Test a valid Five Safes Crate representing a request."""
     do_entity_test(
         ValidROC().five_safes_crate_request,
         Severity.REQUIRED,
         True,
         profile_identifier="five-safes-crate",
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
+        skip_checks=[ SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
     )
 
 
-def test_valid_five_safes_crate_result_required():
+def test_valid_five_safes_crate_result_required(skip_spec_version_identifier):
     """Test a valid Five Safes Crate representing a result."""
     do_entity_test(
         ValidROC().five_safes_crate_result,
         Severity.REQUIRED,
         True,
         profile_identifier="five-safes-crate",
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
+    )
+
+def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
+    """Test a valid Five Safes Crate representing a result."""
+    do_entity_test(
+        ValidROC().five_safes_crate_multiple_context,
+        Severity.REQUIRED,
+        True,
+        profile_identifier="five-safes-crate",
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
     )

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -55,6 +55,8 @@ def test_valid_five_safes_crate_request_required(skip_spec_version_identifier):
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
             skip_spec_version_identifier,
         ],
+        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
+        disable_inherited_profiles_reporting=True,
     )
 
 
@@ -69,6 +71,8 @@ def test_valid_five_safes_crate_result_required(skip_spec_version_identifier):
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
             skip_spec_version_identifier,
         ],
+        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
+        disable_inherited_profiles_reporting=True,
     )
 
 
@@ -83,4 +87,6 @@ def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
             SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
             skip_spec_version_identifier,
         ],
+        # argument below can be removed when https://github.com/crs4/rocrate-validator/issues/126 is fixed
+        disable_inherited_profiles_reporting=True,
     )

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -34,10 +34,12 @@ def skip_spec_version_identifier():
     rocrate_profile = services.get_profile("ro-crate")
     if not rocrate_profile:
         raise RuntimeError("Unable to load the RO-Crate profile")
-    check_conformsTo_version = \
-        rocrate_profile.get_requirement_check("Metadata File Descriptor entity: `conformsTo` property")
-    assert check_conformsTo_version, \
-        'Unable to find the requirement "Metadata File Descriptor entity: `conformsTo` property"'
+    check_conformsTo_version = rocrate_profile.get_requirement_check(
+        "Metadata File Descriptor entity: `conformsTo` property"
+    )
+    assert (
+        check_conformsTo_version
+    ), 'Unable to find the requirement "Metadata File Descriptor entity: `conformsTo` property"'
     SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER = check_conformsTo_version.identifier
     return SKIP_CONFORMSTO_VERSION_CHECK_IDENTIFIER
 
@@ -49,7 +51,10 @@ def test_valid_five_safes_crate_request_required(skip_spec_version_identifier):
         Severity.REQUIRED,
         True,
         profile_identifier="five-safes-crate",
-        skip_checks=[ SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
+        skip_checks=[
+            SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
+            skip_spec_version_identifier,
+        ],
     )
 
 
@@ -60,8 +65,12 @@ def test_valid_five_safes_crate_result_required(skip_spec_version_identifier):
         Severity.REQUIRED,
         True,
         profile_identifier="five-safes-crate",
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
+        skip_checks=[
+            SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
+            skip_spec_version_identifier,
+        ],
     )
+
 
 def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
     """Test a valid Five Safes Crate representing a result."""
@@ -70,5 +79,8 @@ def test_valid_five_safes_crate_multiple_context(skip_spec_version_identifier):
         Severity.REQUIRED,
         True,
         profile_identifier="five-safes-crate",
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER, skip_spec_version_identifier],
+        skip_checks=[
+            SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
+            skip_spec_version_identifier,
+        ],
     )

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -98,6 +98,10 @@ class ValidROC:
     @property
     def five_safes_crate_result(self) -> Path:
         return VALID_CRATES_DATA_PATH / "five-safes-crate-result"
+    
+    @property
+    def five_safes_crate_multiple_context(self) -> Path:
+        return VALID_CRATES_DATA_PATH / "five-safes-crate-multiple-context"
 
 
 class InvalidFileDescriptor:
@@ -980,20 +984,15 @@ class InvalidProvRC:
 
 class Invalid5sROC:
 
-    base_path = INVALID_CRATES_DATA_PATH / "6_five_safes_crate/"
+    base_path = INVALID_CRATES_DATA_PATH / "five_safes_crate/"
 
     @property
-    def funding_project_no_name(self) -> Path:
-        return self.base_path / "funding_project_no_name"
+    def context_multiple_wrong_version(self) -> Path:
+        return self.base_path / "context_multiple_wrong_version"
 
     @property
-    def root_data_entity_no_source_organization(self) -> Path:
-        return self.base_path / "root_data_entity_no_source_organization"
-
-    @property
-    def root_data_entity_source_organization_not_entity(self) -> Path:
-        return self.base_path / "root_data_entity_source_organization_not_entity"
-
+    def context_single_wrong_version(self) -> Path:
+        return self.base_path / "context_single_wrong_version"
 
 class InvalidMultiProfileROC:
 

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -98,7 +98,7 @@ class ValidROC:
     @property
     def five_safes_crate_result(self) -> Path:
         return VALID_CRATES_DATA_PATH / "five-safes-crate-result"
-    
+
     @property
     def five_safes_crate_multiple_context(self) -> Path:
         return VALID_CRATES_DATA_PATH / "five-safes-crate-multiple-context"
@@ -993,6 +993,7 @@ class Invalid5sROC:
     @property
     def context_single_wrong_version(self) -> Path:
         return self.base_path / "context_single_wrong_version"
+
 
 class InvalidMultiProfileROC:
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -103,14 +103,10 @@ def do_entity_test(
         profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
         rocrate_entity_patch: Optional[dict] = None,
         rocrate_entity_mod_sparql: Optional[str] = None,
-        skip_checks: Optional[list[str]] = (),
-        **kwargs
+        skip_checks: Optional[list[str]] = ()
 ):
     """
-    Shared function to test a RO-Crate entity.
-
-    Additional keyword arguments (kwargs) are passed through to ValidationSettings,
-    allowing individual tests to tweak settings as needed.
+    Shared function to test a RO-Crate entity
     """
     assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), \
         "Cannot use rocrate_entity_patch and rocrate_entity_mod_sparql together"
@@ -172,18 +168,14 @@ def do_entity_test(
         abort_on_first = abort_on_first
 
         # validate RO-Crate
-        result: models.ValidationResult = services.validate(
-            models.ValidationSettings(
-                **{
-                    "rocrate_uri": rocrate_path,
-                    "requirement_severity": requirement_severity,
-                    "abort_on_first": abort_on_first,
-                    "profile_identifier": profile_identifier,
-                    "skip_checks": skip_checks,
-                },
-                **kwargs,
-            )
-        )
+        result: models.ValidationResult = \
+            services.validate(models.ValidationSettings(**{
+                "rocrate_uri": rocrate_path,
+                "requirement_severity": requirement_severity,
+                "abort_on_first": abort_on_first,
+                "profile_identifier": profile_identifier,
+                "skip_checks": skip_checks
+            }))
         logger.debug("Expected validation result: %s", expected_validation_result)
 
         assert result.context is not None, "Validation context should not be None"

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-SPARQL_PREFIXES = """PREFIX schema: <http://schema.org/>
+SPARQL_PREFIXES = """
+PREFIX schema: <http://schema.org/>
+PREFIX dct: <http://purl.org/dc/terms/>
 """
 
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -107,7 +107,7 @@ def do_entity_test(
     """
     Shared function to test a RO-Crate entity.
 
-    Additional keyword arguments (kwargs) are passed through to ValidationSettings, 
+    Additional keyword arguments (kwargs) are passed through to ValidationSettings,
     allowing individual tests to tweak settings as needed.
     """
     assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), \

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -101,10 +101,14 @@ def do_entity_test(
         profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
         rocrate_entity_patch: Optional[dict] = None,
         rocrate_entity_mod_sparql: Optional[str] = None,
-        skip_checks: Optional[list[str]] = ()
+        skip_checks: Optional[list[str]] = (),
+        **kwargs
 ):
     """
-    Shared function to test a RO-Crate entity
+    Shared function to test a RO-Crate entity.
+
+    Additional keyword arguments (kwargs) are passed through to ValidationSettings, 
+    allowing individual tests to tweak settings as needed.
     """
     assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), \
         "Cannot use rocrate_entity_patch and rocrate_entity_mod_sparql together"
@@ -172,7 +176,8 @@ def do_entity_test(
                 "requirement_severity": requirement_severity,
                 "abort_on_first": abort_on_first,
                 "profile_identifier": profile_identifier,
-                "skip_checks": skip_checks
+                "skip_checks": skip_checks,
+                **kwargs
             }))
         logger.debug("Expected validation result: %s", expected_validation_result)
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -107,7 +107,7 @@ def do_entity_test(
     """
     Shared function to test a RO-Crate entity.
 
-    Additional keyword arguments (kwargs) are passed through to ValidationSettings, 
+    Additional keyword arguments (kwargs) are passed through to ValidationSettings,
     allowing individual tests to tweak settings as needed.
     """
     assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), \
@@ -184,7 +184,7 @@ def do_entity_test(
         assert result.context is not None, "Validation context should not be None"
         f"Expected requirement severity to be {requirement_severity}, but got {result.context.requirement_severity}"
         assert result.passed() == expected_validation_result, \
-            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
+            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}. {result.failed_requirements} {result.failed_checks} {[issue.message for issue in result.get_issues(requirement_severity)]}"
 
         # check requirement
         failed_requirements = [_.name for _ in result.failed_requirements]
@@ -196,7 +196,7 @@ def do_entity_test(
         for expected_triggered_requirement in expected_triggered_requirements:
             if expected_triggered_requirement not in failed_requirements:
                 assert False, f"The expected requirement " \
-                    f"\"{expected_triggered_requirement}\" was not found in the failed requirements"
+                    f"\"{expected_triggered_requirement}\" was not found in the failed requirements {failed_requirements}"
 
         # check requirement issues
         detected_issues = [issue.message for issue in result.get_issues(requirement_severity)
@@ -205,7 +205,7 @@ def do_entity_test(
         logger.debug("Expected issues: %s", expected_triggered_issues)
         for expected_issue in expected_triggered_issues:
             if not any(expected_issue in issue for issue in detected_issues):  # support partial match
-                assert False, f"The expected issue \"{expected_issue}\" was not found in the detected issues"
+                assert False, f"The expected issue \"{expected_issue}\" was not found in the detected issues {detected_issues}"
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.exception(e)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -107,7 +107,7 @@ def do_entity_test(
     """
     Shared function to test a RO-Crate entity.
 
-    Additional keyword arguments (kwargs) are passed through to ValidationSettings,
+    Additional keyword arguments (kwargs) are passed through to ValidationSettings, 
     allowing individual tests to tweak settings as needed.
     """
     assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), \
@@ -184,7 +184,7 @@ def do_entity_test(
         assert result.context is not None, "Validation context should not be None"
         f"Expected requirement severity to be {requirement_severity}, but got {result.context.requirement_severity}"
         assert result.passed() == expected_validation_result, \
-            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}. {result.failed_requirements} {result.failed_checks} {[issue.message for issue in result.get_issues(requirement_severity)]}"
+            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
 
         # check requirement
         failed_requirements = [_.name for _ in result.failed_requirements]
@@ -196,7 +196,7 @@ def do_entity_test(
         for expected_triggered_requirement in expected_triggered_requirements:
             if expected_triggered_requirement not in failed_requirements:
                 assert False, f"The expected requirement " \
-                    f"\"{expected_triggered_requirement}\" was not found in the failed requirements {failed_requirements}"
+                    f"\"{expected_triggered_requirement}\" was not found in the failed requirements"
 
         # check requirement issues
         detected_issues = [issue.message for issue in result.get_issues(requirement_severity)
@@ -205,7 +205,7 @@ def do_entity_test(
         logger.debug("Expected issues: %s", expected_triggered_issues)
         for expected_issue in expected_triggered_issues:
             if not any(expected_issue in issue for issue in detected_issues):  # support partial match
-                assert False, f"The expected issue \"{expected_issue}\" was not found in the detected issues {detected_issues}"
+                assert False, f"The expected issue \"{expected_issue}\" was not found in the detected issues"
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.exception(e)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -170,15 +170,18 @@ def do_entity_test(
         abort_on_first = abort_on_first
 
         # validate RO-Crate
-        result: models.ValidationResult = \
-            services.validate(models.ValidationSettings(**{
-                "rocrate_uri": rocrate_path,
-                "requirement_severity": requirement_severity,
-                "abort_on_first": abort_on_first,
-                "profile_identifier": profile_identifier,
-                "skip_checks": skip_checks,
-                **kwargs
-            }))
+        result: models.ValidationResult = services.validate(
+            models.ValidationSettings(
+                **{
+                    "rocrate_uri": rocrate_path,
+                    "requirement_severity": requirement_severity,
+                    "abort_on_first": abort_on_first,
+                    "profile_identifier": profile_identifier,
+                    "skip_checks": skip_checks,
+                },
+                **kwargs,
+            )
+        )
         logger.debug("Expected validation result: %s", expected_validation_result)
 
         assert result.context is not None, "Validation context should not be None"


### PR DESCRIPTION
| # | Rule | sh:severity |
| -- | -- | -- |
| 1 | ro-crate-metadata.json MUST conform to RO-Crate 1.2 or a later minor version. | sh:Violation |
| 2 |  `@context` MUST be "https://w3id.org/ro/crate/1.2-DRAFT/context" (i) | sh:Violation| 

(i) expanded to support 1.2-DRAFT, 1.2, or later minor version, to align with the other rule.

Adds a few example crates with variations on the `@context`, because this can't be modified with SPARQL.

~Includes a workaround for https://github.com/crs4/rocrate-validator/issues/126 (which means the `conformsTo` check in the 1.1 profile is unskippable) - by disabling reporting of inherited profile checks when checking the valid 5s crates. I think this is ok as we really only need to test that the five-safes-crates profile is working, not the inherited ones.~ no longer applicable

Also deactivates the `conformsTo` check in the 1.1 profile so it doesn't interfere.