### PR TITLE
Single Publishing Phase check - all AssessActions should be referenced from the RDE

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -29,7 +29,7 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
     sh:targetClass schema:CreateAction ;
 
     sh:property [
-        sh:a sh:PropertyShape ;
+        a sh:PropertyShape ;
         sh:name "name" ;
         sh:minCount 1 ;    
         sh:description "Workflow (CreateAction) MUST have a name string of at least 10 characters." ;

--- a/rocrate_validator/profiles/five-safes-crate/must/16_publishing_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/16_publishing_phase.ttl
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 eScience Lab, The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix purl: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+five-safes-crate:AllAssessActionsMentioned
+    a sh:NodeShape ;
+    sh:name "All AssessActions are mentioned from Root Data Entity" ;
+    sh:description "All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`." ;
+    sh:targetClass schema:AssessAction;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "AssessAction mentions from RDE" ;
+        sh:description "All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`." ;
+        sh:path [ sh:inversePath schema:mentions ] ;
+        sh:node ro-crate:RootDataEntity ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`." ;
+    ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/8_disclosure_phase.ttl
@@ -42,7 +42,7 @@ five-safes-crate:DisclosureObjectHasDescriptiveNameAndIsAssessAction
     ] ;
 
     sh:property [
-        sh:a sh:PropertyShape ;
+        a sh:PropertyShape ;
         sh:name "AssessAction" ;
         sh:description "DisclosureCheck MUST be a `schema:AssessAction`." ;
         sh:path rdf:type ;
@@ -53,7 +53,7 @@ five-safes-crate:DisclosureObjectHasDescriptiveNameAndIsAssessAction
     ] ;
 
     sh:property [
-        sh:a sh:PropertyShape ;
+        a sh:PropertyShape ;
         sh:name "name" ;
         sh:description "DisclosureCheck MUST have a name string of at least 20 characters." ;
         sh:path schema:name ;

--- a/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator.models import Severity
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test, SPARQL_PREFIXES
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+# ----- MUST fails tests
+
+
+def test_5src_assess_action_not_referenced_from_rde():
+    sparql = SPARQL_PREFIXES + """
+        DELETE {
+            <./> schema:mentions ?this .
+        }
+        WHERE {
+            ?this a schema:AssessAction .
+            <./> schema:mentions ?this .
+        }
+        """
+
+    do_entity_test(
+        rocrate_path=ValidROC().five_safes_crate_result,
+        requirement_severity=Severity.REQUIRED,
+        expected_validation_result=False,
+        expected_triggered_requirements=["All AssessActions are mentioned from Root Data Entity"],
+        expected_triggered_issues=["All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`."],
+        profile_identifier="five-safes-crate",
+        rocrate_entity_mod_sparql=sparql,
+    )

--- a/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 
 
 def test_5src_assess_action_not_referenced_from_rde():
-    sparql = SPARQL_PREFIXES + """
+    sparql = (
+        SPARQL_PREFIXES
+        + """
         DELETE {
             <./> schema:mentions ?this .
         }
@@ -35,13 +37,19 @@ def test_5src_assess_action_not_referenced_from_rde():
             <./> schema:mentions ?this .
         }
         """
+    )
 
     do_entity_test(
         rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=["All AssessActions are mentioned from Root Data Entity"],
-        expected_triggered_issues=["All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`."],
+        expected_triggered_requirements=[
+            "All AssessActions are mentioned from Root Data Entity"
+        ],
+        expected_triggered_issues=[
+            "All AssessAction entities in the crate MUST be referenced from "
+            "the Root Dataset via `mentions`."
+        ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
     )


### PR DESCRIPTION
Implements this check which @alexhambley and I agreed to be a priority.

| # | Rule | `sh:severity` |
| -- | -- | -- |
| 1 | All AssessAction entities in the crate MUST be referenced from the Root Dataset via `mentions`. | sh:Violation 

Other checks from this phase won't be implemented for now.