### PR TITLE
add UoM to copyright in 5S-ROCrate test headers

### DIFF
--- a/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_12_check_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_12_check_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_13_validation_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_13_validation_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_14_workflow_retrieval_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_14_workflow_retrieval_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_15_metadata_file.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_16_publishing_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_1_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_1_requesting_agent.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_1_responsible_project.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_1_responsible_project.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_1_root_data_entity_metadata.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_1_root_data_entity_metadata.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_4_signoff_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_4_signoff_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_6_workflow_reference.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_6_workflow_reference.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_8_disclosure_phase.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_5src_9_inputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_9_inputs.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/profiles/five-safes-crate/test_valid_5src.py
+++ b/tests/integration/profiles/five-safes-crate/test_valid_5src.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 CRS4
+# Copyright (c) 2025-2026 eScience Lab, The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adding eScience lab to the copyright headers for the tests.