### PR TITLE
71 flatten `3_timestamp_format.ttl` files

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/3_timestamp_format.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/3_timestamp_format.ttl
@@ -23,6 +23,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+#=== MUST shapes ===#
+
 # to ensure the entity id will be included in any error message,
 # target all entities which have startTime and/or endTime properties using sh:targetSubjectsOf,
 # then we use sh:property to validate the values of those properties.
@@ -52,3 +54,11 @@ five-safes-crate:TimeStampFormat
         sh:severity sh:Violation ;
         sh:message "All `startTime` and `endTime` values MUST follow the RFC 3339 standard (YYYY-MM-DD'T'hh:mm:ss[.fraction](Z | ±hh:mm))." ;
     ] .
+
+
+#=== SHOULD shapes ===#
+# (none)
+
+
+#=== MAY shapes ===#
+# (none)


### PR DESCRIPTION
This PR addresses #71.

@elichad @alexhambley @douglowe 
The work done for this PR consists only of flattening the ttl files pertaining to the 3_timestamp_format rulset with no change in the code.
A full PR review is not needed. If you are OK with me merging into develop, please give me a thumb up.