### PR TITLE
Merged `9_inputs.tll` files.

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
@@ -34,6 +34,7 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
     a sh:NodeShape ;
     sh:name "Input" ;
     sh:description "" ;
+    sh:severity sh:Warning ;
     sh:target [
         a sh:SPARQLTarget ;
         sh:prefixes ro-crate:sparqlPrefixes ;
@@ -58,7 +59,6 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
               }
             }
         """ ;
-        sh:severity sh:Warning ;
         sh:message "Input SHOULD reference a FormalParameter using exampleOfWork" ;
     ] .
 

--- a/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
@@ -24,6 +24,12 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+#=== MUST shapes ===#
+# (none)
+
+
+#=== SHOULD shapes ===#
+
 five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
     a sh:NodeShape ;
     sh:name "Input" ;
@@ -42,6 +48,7 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
         a sh:SPARQLConstraint ;
         sh:name "exampleOfWork" ;
         sh:description "Input SHOULD reference a FormalParameter using exampleOfWork" ;
+        sh:severity sh:Warning ;
         
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
@@ -52,6 +59,9 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
               }
             }
         """ ;
-        sh:severity sh:Warning ;
         sh:message "Input SHOULD reference a FormalParameter using exampleOfWork" ;
     ] .
+
+
+#=== MAY shapes ===#
+# (none)

--- a/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/9_inputs.ttl
@@ -48,7 +48,6 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
         a sh:SPARQLConstraint ;
         sh:name "exampleOfWork" ;
         sh:description "Input SHOULD reference a FormalParameter using exampleOfWork" ;
-        sh:severity sh:Warning ;
         
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
@@ -59,6 +58,7 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
               }
             }
         """ ;
+        sh:severity sh:Warning ;
         sh:message "Input SHOULD reference a FormalParameter using exampleOfWork" ;
     ] .
 


### PR DESCRIPTION
This PR addresses #76.

@elichad @alexhambley @douglowe
The work done for this PR consists only of flattening the `ttl` files pertaining to the 9_inputs ruleset with no change in the code (apart from moving `sh:severity` from the sparql constraint to the parent `sh:NodeShape` when necessary).
A full PR review is not needed. If you are OK with me merging into develop, please give me a thumb up.