### PR TITLE
Merged `10_outputs.tll` files.

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/10_outputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/10_outputs.ttl
@@ -22,7 +22,13 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:WorkflowRunActionHasResultIfActionCompleted
+#=== MUST shapes ===#
+# (none)
+
+
+#=== SHOULD shapes ===#
+
+five-safes-crate:CreateActionHasResultIfActionCompleted
   a sh:NodeShape ;
   sh:name "WorkflowRunAction" ;
   sh:description "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `schema:result` property." ;
@@ -85,3 +91,7 @@ five-safes-crate:WorkflowRunActionResultOutputsHaveAllowedTypes
         sh:class schema:PropertyValue;
       ]
     ) .
+
+
+#=== MAY shapes ===#
+# (none)


### PR DESCRIPTION
This PR addresses #77.

@elichad @alexhambley @douglowe
The work done for this PR consists only of flattening the `ttl` files pertaining to the 10_outputs ruleset with no change in the code (apart from moving `sh:severity` from the sparql constraint to the parent `sh:NodeShape` when necessary).
A full PR review is not needed. If you are OK with me merging into develop, please give me a thumb up.