### PR TITLE
Infer WorkflowRun from CreateAction in five-safes SHACL profiles - NEW

### DIFF
--- a/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
@@ -22,6 +22,35 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
@@ -34,11 +63,11 @@ five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
         a sh:SPARQLTarget ;
         sh:select """
             PREFIX schema: <http://schema.org/>
-            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rocrate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/>
 
             SELECT ?this
             WHERE {
-                ?this rdf:type schema:CreateAction ;
+                ?this a rocrate:WorkflowRun ;
                       schema:actionStatus ?status .
                 FILTER(?status IN (
                     "http://schema.org/CompletedActionStatus",

--- a/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
@@ -38,7 +38,7 @@ five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
 
             SELECT ?this
             WHERE {
-                ?this a rocrate:WorkflowRun ;
+                ?this a rocrate:WorkflowRunAction ;
                       schema:actionStatus ?status .
                 FILTER(?status IN (
                     "http://schema.org/CompletedActionStatus",

--- a/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/11_workflow_execution_phase.ttl
@@ -22,35 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 five-safes-crate:WorkflowexecutionObjectHasStartTimeIfBegun
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;

--- a/rocrate_validator/profiles/five-safes-crate/may/1_responsible_project.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/1_responsible_project.ttl
@@ -22,6 +22,35 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 five-safes-crate:ResponsibleProject
     a sh:NodeShape ;
     sh:name "Responsible Project" ;
@@ -30,7 +59,7 @@ five-safes-crate:ResponsibleProject
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a schema:CreateAction ;
+              ?action a ro-crate:WorkflowRun ;
                       schema:agent ?agent .
               ?agent schema:memberOf ?this .
             }

--- a/rocrate_validator/profiles/five-safes-crate/may/1_responsible_project.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/may/1_responsible_project.ttl
@@ -30,7 +30,7 @@ five-safes-crate:ResponsibleProject
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a ro-crate:WorkflowRun ;
+              ?action a ro-crate:WorkflowRunAction ;
                       schema:agent ?agent .
               ?agent schema:memberOf ?this .
             }

--- a/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
@@ -12,45 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@prefix ro: <./> .
 @prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
-@prefix five-safes-crate: <https://github.com/eScienceLab/rocrate-validator/profiles/five-safes-crate/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix validator: <https://github.com/crs4/rocrate-validator/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:ResponsibleProject
-    a sh:NodeShape ;
-    sh:name "Responsible Project" ;
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:order 1 ;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
     sh:target [
         a sh:SPARQLTarget ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-            SELECT DISTINCT ?this WHERE {
-              ?action a ro-crate:WorkflowRun ;
-                      schema:agent ?agent .
-              ?agent schema:memberOf ?this .
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root a ro-crate:RootDataEntity ;
+                      schema:mainEntity ?instrument .
             }
         """
     ] ;
 
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "funding" ;
-        sh:path schema:funding;
-        sh:minCount 1 ;
-        sh:severity sh:Info ;
-        sh:message """The Responsible Project does not have the property `funding`.""" ;
-    ] ;
-
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "member" ;
-        sh:path schema:member;
-        sh:minCount 1 ;
-        sh:severity sh:Info ;
-        sh:message """The Responsible Project does not have the property `member`.""" ;
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
@@ -43,5 +43,5 @@ ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
         a sh:TripleRule ;
         sh:subject sh:this ;
         sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
+        sh:object ro-crate:WorkflowRunAction ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/0_workflow_run_inference.ttl
@@ -20,7 +20,7 @@
 
 
 ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:order 1 ;
+    sh:order 1 ; # load this check after ro-crate:FindRootDataEntity; pySHACL sorts rules by sh:order before execution
     sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
     sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
     This is identified by checking that the CreateAction entity has an `instrument` property

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -32,12 +32,12 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
         a sh:PropertyShape ;
         sh:name "name" ;
         sh:minCount 1 ;    
-        sh:description "WorkflowRun MUST have a name string of at least 10 characters." ;
+        sh:description "The `CreateAction` corresponding to the workflow run MUST have a name string of at least 10 characters." ;
         sh:path schema:name ;
         sh:datatype xsd:string ;
         sh:minLength 10 ;
         sh:severity sh:Violation ;
-        sh:message "WorkflowRun MUST have a name string of at least 10 characters." ;
+        sh:message "The `CreateAction` corresponding to the workflow run MUST have a name string of at least 10 characters." ;
     ] .
 
 
@@ -49,7 +49,7 @@ five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
         a sh:PropertyShape ;
         sh:minCount 1 ;
         sh:name "actionStatus" ;
-        sh:description "WorkflowRun MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
+        sh:description "`CreateAction` MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
         sh:path schema:actionStatus ;
         sh:in (
             "http://schema.org/PotentialActionStatus"
@@ -58,5 +58,5 @@ five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
             "http://schema.org/FailedActionStatus"
         ) ;
         sh:severity sh:Violation ;
-        sh:message "WorkflowRun MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
+        sh:message "`CreateAction` MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -23,35 +23,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 five-safes-crate:WorkflowMustHaveDescriptiveName
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -26,7 +26,7 @@
 five-safes-crate:WorkflowMustHaveDescriptiveName
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:targetClass ro-crate:WorkflowRun ;
+    sh:targetClass ro-crate:WorkflowRunAction ;
 
     sh:property [
         a sh:PropertyShape ;
@@ -44,7 +44,7 @@ five-safes-crate:WorkflowMustHaveDescriptiveName
 five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:targetClass ro-crate:WorkflowRun ;
+    sh:targetClass ro-crate:WorkflowRunAction ;
     sh:property [
         a sh:PropertyShape ;
         sh:minCount 1 ;

--- a/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/11_workflow_execution_phase.ttl
@@ -23,33 +23,62 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 five-safes-crate:WorkflowMustHaveDescriptiveName
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:targetClass schema:CreateAction ;
+    sh:targetClass ro-crate:WorkflowRun ;
 
     sh:property [
         a sh:PropertyShape ;
         sh:name "name" ;
         sh:minCount 1 ;    
-        sh:description "Workflow (CreateAction) MUST have a name string of at least 10 characters." ;
+        sh:description "WorkflowRun MUST have a name string of at least 10 characters." ;
         sh:path schema:name ;
         sh:datatype xsd:string ;
         sh:minLength 10 ;
         sh:severity sh:Violation ;
-        sh:message "Workflow (CreateAction) MUST have a name string of at least 10 characters." ;
+        sh:message "WorkflowRun MUST have a name string of at least 10 characters." ;
     ] .
 
 
 five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:targetClass schema:CreateAction ;
+    sh:targetClass ro-crate:WorkflowRun ;
     sh:property [
         a sh:PropertyShape ;
         sh:minCount 1 ;
         sh:name "actionStatus" ;
-        sh:description "WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
+        sh:description "WorkflowRun MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
         sh:path schema:actionStatus ;
         sh:in (
             "http://schema.org/PotentialActionStatus"
@@ -58,5 +87,5 @@ five-safes-crate:WorkflowMustHaveActionStatusWithAllowedValues
             "http://schema.org/FailedActionStatus"
         ) ;
         sh:severity sh:Violation ;
-        sh:message "WorkflowExecution MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
+        sh:message "WorkflowRun MUST have an actionStatus with an allowed value (see https://schema.org/ActionStatusType)." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -22,7 +22,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:RootDataEntityMentionsWorkflowRun
+five-safes-crate:RootDataEntityMentionsWorkflowRunAction
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
     sh:targetClass ro-crate:RootDataEntity ;
@@ -33,7 +33,7 @@ five-safes-crate:RootDataEntityMentionsWorkflowRun
         sh:name "mentions" ;
         sh:path schema:mentions;
         sh:qualifiedValueShape [
-            sh:class ro-crate:WorkflowRun ;
+            sh:class ro-crate:WorkflowRunAction ;
         ] ;
         sh:qualifiedMinCount 1 ;
         sh:severity sh:Violation ;
@@ -41,7 +41,7 @@ five-safes-crate:RootDataEntityMentionsWorkflowRun
     ] .
 
 
-five-safes-crate:WorkflowRunExistence
+five-safes-crate:WorkflowRunActionExistence
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
     sh:targetClass ro-crate:RootDataEntity ;
@@ -49,13 +49,13 @@ five-safes-crate:WorkflowRunExistence
 
     sh:sparql [
         a sh:SPARQLConstraint ;
-        sh:name "WorkflowRun" ;
+        sh:name "WorkflowRunAction" ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT $this
             WHERE {
                 FILTER NOT EXISTS {
-                    ?workflowRun a ro-crate:WorkflowRun .
+                    ?workflowRunAction a ro-crate:WorkflowRunAction .
                 }
             }
         """ ;
@@ -65,8 +65,8 @@ five-safes-crate:WorkflowRunExistence
 
 five-safes-crate:WorkflowRunObject
     a sh:NodeShape ;
-    sh:name "WorkflowRun" ;
-    sh:targetClass ro-crate:WorkflowRun ;
+    sh:name "WorkflowRunAction" ;
+    sh:targetClass ro-crate:WorkflowRunAction ;
     sh:description "" ; 
     sh:severity sh:Violation ; # Apply to all property shapes / constraints below
 

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -59,7 +59,7 @@ five-safes-crate:WorkflowRunActionExistence
                 }
             }
         """ ;
-        sh:message "The `CreateAction` entity corresponding to the workflow run MUST reference through its property `instrument` the same entity as `RootData Entity` --> `mainEntity`" ;
+        sh:message "The CreateAction entity corresponding to the workflow MUST reference, as an instrument, the entity that is referenced as mainEntity by the RO-Crate" ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -81,5 +81,5 @@ five-safes-crate:WorkflowRunObject
                 FILTER NOT EXISTS {  ?object a ?type . }
             }
         """ ;
-        sh:message "Each `object` in the `CreateAction` entity corresponding to the workflow run MUST reference an existing entity." ;
+        sh:message "In the `CreateAction` entity corresponding to the workflow run, each `object`  MUST reference an existing entity." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -22,36 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    # Expand data graph with triples from the file data entity
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 five-safes-crate:RootDataEntityMentionsWorkflowRun
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -22,7 +22,37 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:RootDataEntityMentionsCreateAction
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    # Expand data graph with triples from the file data entity
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
+five-safes-crate:RootDataEntityMentionsWorkflowRun
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
     sh:targetClass ro-crate:RootDataEntity ;
@@ -33,42 +63,43 @@ five-safes-crate:RootDataEntityMentionsCreateAction
         sh:name "mentions" ;
         sh:path schema:mentions;
         sh:qualifiedValueShape [
-            sh:class schema:CreateAction ;
+            sh:class ro-crate:WorkflowRun ;
         ] ;
         sh:qualifiedMinCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`" ;
+        sh:message "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`" ;
     ] .
 
 
-five-safes-crate:CreateActionInstrumentAndStatus
+five-safes-crate:WorkflowRunExistence
     a sh:NodeShape ;
-    sh:name "CreateAction" ;
-    sh:targetClass schema:CreateAction ;
+    sh:name "RootDataEntity" ;
+    sh:targetClass ro-crate:RootDataEntity ;
+    sh:description "" ;
+
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:name "WorkflowRun" ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT $this
+            WHERE {
+                FILTER NOT EXISTS {
+                    ?workflowRun a ro-crate:WorkflowRun .
+                }
+            }
+        """ ;
+        sh:message "The crate MUST contain at least one `WorkflowRun` entity" ;
+    ] .
+
+
+five-safes-crate:WorkflowRunObject
+    a sh:NodeShape ;
+    sh:name "WorkflowRun" ;
+    sh:targetClass ro-crate:WorkflowRun ;
     sh:description "" ; 
     sh:severity sh:Violation ; # Apply to all property shapes / constraints below
 
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "instrument" ;
-        sh:path schema:instrument;
-        sh:minCount 1 ;
-        sh:message "`CreateAction` MUST have the `instrument` property" ;
-    ]  ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:name "instrument" ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-        SELECT $this ?main ?instrument
-        WHERE {
-            ?root schema:mainEntity ?main .
-            $this schema:instrument ?instrument .
-            FILTER (?instrument != ?main)
-        }
-        """ ;
-        sh:message "`CreateAction` --> `instrument` MUST reference the same entity as `Root Data Entity` --> `mainEntity`" ;
-    ] ;
     sh:sparql [
         a sh:SPARQLConstraint ;
         sh:prefixes ro-crate:sparqlPrefixes ;
@@ -80,5 +111,5 @@ five-safes-crate:CreateActionInstrumentAndStatus
                 FILTER NOT EXISTS {  ?object a ?type . }
             }
         """ ;
-        sh:message "Each `object` in `CreateAction` MUST reference an existing entity." ;
+        sh:message "Each `object` in `WorkflowRun` MUST reference an existing entity." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -37,7 +37,7 @@ five-safes-crate:RootDataEntityMentionsWorkflowRun
         ] ;
         sh:qualifiedMinCount 1 ;
         sh:severity sh:Violation ;
-        sh:message "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`" ;
+        sh:message "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`" ;
     ] .
 
 
@@ -59,7 +59,7 @@ five-safes-crate:WorkflowRunExistence
                 }
             }
         """ ;
-        sh:message "The crate MUST contain at least one `WorkflowRun` entity" ;
+        sh:message "The crate MUST contain at least one `CreateAction` (corresponding to the workflow run)" ;
     ] .
 
 
@@ -81,5 +81,5 @@ five-safes-crate:WorkflowRunObject
                 FILTER NOT EXISTS {  ?object a ?type . }
             }
         """ ;
-        sh:message "Each `object` in `WorkflowRun` MUST reference an existing entity." ;
+        sh:message "Each `object` in the `CreateAction` entity corresponding to the workflow run MUST reference an existing entity." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/must/7_requested_workflow_run.ttl
@@ -59,7 +59,7 @@ five-safes-crate:WorkflowRunActionExistence
                 }
             }
         """ ;
-        sh:message "The crate MUST contain at least one `CreateAction` (corresponding to the workflow run)" ;
+        sh:message "The `CreateAction` entity corresponding to the workflow run MUST reference through its property `instrument` the same entity as `RootData Entity` --> `mainEntity`" ;
     ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/ontology.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/ontology.ttl
@@ -31,7 +31,7 @@
 # # #    Classes
 # # #################################################################
 
-# Declare a WorkflowRun class
-ro-crate:WorkflowRun rdf:type owl:Class ;
+# Declare a WorkflowRunAction class
+ro-crate:WorkflowRunAction rdf:type owl:Class ;
   rdfs:subClassOf schema:CreateAction ;
-  rdfs:label "WorkflowRun"@en .
+  rdfs:label "WorkflowRunAction"@en .

--- a/rocrate_validator/profiles/five-safes-crate/ontology.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/ontology.ttl
@@ -1,0 +1,37 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix rocrate: <https://w3id.org/ro/crate/1.1/> .
+@prefix bioschemas: <https://bioschemas.org/> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix isa-ro-crate: <https://github.com/crs4/rocrate-validator/profiles/isa-ro-crate/> .
+
+<urn:absolute:.> rdf:type owl:Ontology ;
+                  owl:versionIRI <urn:absolute:1.0> .
+
+# # #################################################################
+# # #    Classes
+# # #################################################################
+
+# Declare a WorkflowRun class
+ro-crate:WorkflowRun rdf:type owl:Class ;
+  rdfs:subClassOf schema:CreateAction ;
+  rdfs:label "WorkflowRun"@en .

--- a/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
@@ -22,20 +22,49 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
 
-five-safes-crate:CreateActionHasResultIfActionCompleted
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
+
+five-safes-crate:WorkflowRunHasResultIfActionCompleted
   a sh:NodeShape ;
-  sh:name "CreateAction" ;
-  sh:description "`CreateAction` with CompletedActionStatus SHOULD have the `schema:result` property." ;
+  sh:name "WorkflowRun" ;
+  sh:description "`WorkflowRun` with CompletedActionStatus SHOULD have the `schema:result` property." ;
 
   sh:target [
         a sh:SPARQLTarget ;
-        sh:name "Result" ;
-        sh:description "`CreateAction` with CompletedActionStatus SHOULD have the `schema:result` property." ;
+        sh:name "WorkflowRun" ;
+        sh:description "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property." ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this WHERE {
-              ?this a schema:CreateAction ;
+              ?this a ro-crate:WorkflowRun ;
                       schema:actionStatus "http://schema.org/CompletedActionStatus" .
             }
         """
@@ -48,22 +77,22 @@ five-safes-crate:CreateActionHasResultIfActionCompleted
     sh:path schema:result ;
     sh:minCount 1 ;
     sh:severity sh:Warning ;
-    sh:message "`CreateAction` with CompletedActionStatus SHOULD have the `result` property." ;
+    sh:message "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property." ;
   ] .
 
 
-five-safes-crate:CreateActionResultOutputsHaveAllowedTypes
+five-safes-crate:WorkflowRunResultOutputsHaveAllowedTypes
   a sh:NodeShape ;
     sh:name "Output" ;
     sh:description "Result SHOULD have a `@type` among an allowed set of values." ;
     sh:target [
       a sh:SPARQLTarget ;
+      sh:prefixes ro-crate:sparqlPrefixes ;
       sh:select """
-        PREFIX schema: <http://schema.org/>
         SELECT ?this
         WHERE {
-          ?createAction a schema:CreateAction .
-          ?createAction schema:result ?this .
+          ?workflowRun a ro-crate:WorkflowRun .
+          ?workflowRun schema:result ?this .
         }
       """ ;
     ] ;
@@ -86,4 +115,3 @@ five-safes-crate:CreateActionResultOutputsHaveAllowedTypes
         sh:class schema:PropertyValue;
       ]
     ) .
-

--- a/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
@@ -22,36 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
-
 five-safes-crate:WorkflowRunHasResultIfActionCompleted
   a sh:NodeShape ;
   sh:name "WorkflowRun" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
@@ -25,12 +25,12 @@
 five-safes-crate:WorkflowRunHasResultIfActionCompleted
   a sh:NodeShape ;
   sh:name "WorkflowRun" ;
-  sh:description "`WorkflowRun` with CompletedActionStatus SHOULD have the `schema:result` property." ;
+  sh:description "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `schema:result` property." ;
 
   sh:target [
         a sh:SPARQLTarget ;
         sh:name "WorkflowRun" ;
-        sh:description "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property." ;
+        sh:description "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `result` property." ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this WHERE {
@@ -47,7 +47,7 @@ five-safes-crate:WorkflowRunHasResultIfActionCompleted
     sh:path schema:result ;
     sh:minCount 1 ;
     sh:severity sh:Warning ;
-    sh:message "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property." ;
+    sh:message "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `result` property." ;
   ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/10_outputs.ttl
@@ -22,19 +22,19 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:WorkflowRunHasResultIfActionCompleted
+five-safes-crate:WorkflowRunActionHasResultIfActionCompleted
   a sh:NodeShape ;
-  sh:name "WorkflowRun" ;
+  sh:name "WorkflowRunAction" ;
   sh:description "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `schema:result` property." ;
 
   sh:target [
         a sh:SPARQLTarget ;
-        sh:name "WorkflowRun" ;
+        sh:name "WorkflowRunAction" ;
         sh:description "The `CreateAction` corresponding to the workflow run, with CompletedActionStatus, SHOULD have the `result` property." ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this WHERE {
-              ?this a ro-crate:WorkflowRun ;
+              ?this a ro-crate:WorkflowRunAction ;
                       schema:actionStatus "http://schema.org/CompletedActionStatus" .
             }
         """
@@ -51,7 +51,7 @@ five-safes-crate:WorkflowRunHasResultIfActionCompleted
   ] .
 
 
-five-safes-crate:WorkflowRunResultOutputsHaveAllowedTypes
+five-safes-crate:WorkflowRunActionResultOutputsHaveAllowedTypes
   a sh:NodeShape ;
     sh:name "Output" ;
     sh:description "Result SHOULD have a `@type` among an allowed set of values." ;
@@ -61,8 +61,8 @@ five-safes-crate:WorkflowRunResultOutputsHaveAllowedTypes
       sh:select """
         SELECT ?this
         WHERE {
-          ?workflowRun a ro-crate:WorkflowRun .
-          ?workflowRun schema:result ?this .
+          ?workflowRunAction a ro-crate:WorkflowRunAction .
+          ?workflowRunAction schema:result ?this .
         }
       """ ;
     ] ;

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -23,32 +23,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-five-safes-crate:RootDataEntityShouldMentionWorkflow 
-    a sh:NodeShape ;
-    sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`." ;
-    sh:targetClass ro-crate:RootDataEntity ;
-    sh:sparql [
-        a sh:SPARQLConstraint ; 
-        sh:name "mentions" ;
-        sh:select """
-        PREFIX schema: <http://schema.org/>
-        PREFIX rocrate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/>
-        SELECT $this 
-        WHERE {
-            
-            FILTER NOT EXISTS {
-                $this schema:mentions ?workflowExecution .
-                ?workflowExecution a rocrate:WorkflowRunAction .
-            }
-        }
-        """ ;
-      sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`." ;
-   ] .
-
-
-
 five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -23,29 +23,58 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 
 five-safes-crate:RootDataEntityShouldMentionWorkflow 
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)." ;
+    sh:description "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)." ;
     sh:targetClass ro-crate:RootDataEntity ;
     sh:sparql [
         a sh:SPARQLConstraint ; 
         sh:name "mentions" ;
         sh:select """
         PREFIX schema: <http://schema.org/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rocrate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/>
         SELECT $this 
         WHERE {
             
             FILTER NOT EXISTS {
                 $this schema:mentions ?workflowExecution .
-                ?workflowExecution rdf:type schema:CreateAction .
+                ?workflowExecution a rocrate:WorkflowRun .
             }
         }
         """ ;
       sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)." ;
+      sh:message "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)." ;
    ] .
 
 
@@ -59,11 +88,11 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
         a sh:SPARQLTarget ;
         sh:select """
             PREFIX schema: <http://schema.org/>
-            PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rocrate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/>
 
             SELECT ?this
             WHERE {
-                ?this rdf:type schema:CreateAction ;
+                ?this a rocrate:WorkflowRun ;
                       schema:actionStatus ?status .
                 FILTER(?status IN (
                     "http://schema.org/CompletedActionStatus",

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -23,36 +23,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
-
 five-safes-crate:RootDataEntityShouldMentionWorkflow 
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -26,7 +26,7 @@
 five-safes-crate:RootDataEntityShouldMentionWorkflow 
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)." ;
+    sh:description "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`." ;
     sh:targetClass ro-crate:RootDataEntity ;
     sh:sparql [
         a sh:SPARQLConstraint ; 
@@ -44,7 +44,7 @@ five-safes-crate:RootDataEntityShouldMentionWorkflow
         }
         """ ;
       sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)." ;
+      sh:message "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`." ;
    ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -26,7 +26,7 @@
 five-safes-crate:RootDataEntityShouldMentionWorkflow 
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)." ;
+    sh:description "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)." ;
     sh:targetClass ro-crate:RootDataEntity ;
     sh:sparql [
         a sh:SPARQLConstraint ; 
@@ -44,7 +44,7 @@ five-safes-crate:RootDataEntityShouldMentionWorkflow
         }
         """ ;
       sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)." ;
+      sh:message "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)." ;
    ] .
 
 
@@ -52,7 +52,7 @@ five-safes-crate:RootDataEntityShouldMentionWorkflow
 five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
     a sh:NodeShape ;
     sh:name "WorkflowExecution" ;
-    sh:description "The workflow execution object SHOULD have an endTime property if it has ended." ;
+    sh:description "The workflow run object SHOULD have an endTime property if it has ended." ;
 
     sh:target [
         a sh:SPARQLTarget ;

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -39,7 +39,7 @@ five-safes-crate:RootDataEntityShouldMentionWorkflow
             
             FILTER NOT EXISTS {
                 $this schema:mentions ?workflowExecution .
-                ?workflowExecution a rocrate:WorkflowRun .
+                ?workflowExecution a rocrate:WorkflowRunAction .
             }
         }
         """ ;
@@ -62,7 +62,7 @@ five-safes-crate:WorkflowexecutionObjectHasEndTimeIfEnded
 
             SELECT ?this
             WHERE {
-                ?this a rocrate:WorkflowRun ;
+                ?this a rocrate:WorkflowRunAction ;
                       schema:actionStatus ?status .
                 FILTER(?status IN (
                     "http://schema.org/CompletedActionStatus",

--- a/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/11_workflow_execution_phase.ttl
@@ -26,7 +26,7 @@
 five-safes-crate:RootDataEntityShouldMentionWorkflow 
     a sh:NodeShape ;
     sh:name "RootDataEntity" ;
-    sh:description "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)." ;
+    sh:description "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)." ;
     sh:targetClass ro-crate:RootDataEntity ;
     sh:sparql [
         a sh:SPARQLConstraint ; 
@@ -44,7 +44,7 @@ five-safes-crate:RootDataEntityShouldMentionWorkflow
         }
         """ ;
       sh:severity sh:Warning ;
-      sh:message "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)." ;
+      sh:message "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)." ;
    ] .
 
 

--- a/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
@@ -22,35 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 five-safes-crate:AgentIsMemberOf
     a sh:NodeShape ;
     sh:name "Requesting Agent" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
@@ -30,7 +30,7 @@ five-safes-crate:AgentIsMemberOf
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a rocrate:WorkflowRun ;
+              ?action a rocrate:WorkflowRunAction ;
                       schema:agent ?this .
             }
         """

--- a/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_requesting_agent.ttl
@@ -22,6 +22,35 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 five-safes-crate:AgentIsMemberOf
     a sh:NodeShape ;
     sh:name "Requesting Agent" ;
@@ -30,7 +59,7 @@ five-safes-crate:AgentIsMemberOf
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a schema:CreateAction ;
+              ?action a rocrate:WorkflowRun ;
                       schema:agent ?this .
             }
         """

--- a/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
@@ -33,7 +33,7 @@ five-safes-crate:ResponsibleProjectMemberAndSourceOrganizationIntersection
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a ro-crate:WorkflowRun ;
+              ?action a ro-crate:WorkflowRunAction ;
                       schema:agent ?this .
               ?this a schema:Person ;
                     schema:memberOf ?project ;

--- a/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
@@ -22,35 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 five-safes-crate:ResponsibleProjectMemberAndSourceOrganizationIntersection
     a sh:NodeShape ;
     sh:name "Organizations (members of Responsible Project)" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/1_responsible_project.ttl
@@ -22,6 +22,35 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 five-safes-crate:ResponsibleProjectMemberAndSourceOrganizationIntersection
     a sh:NodeShape ;
     sh:name "Organizations (members of Responsible Project)" ;
@@ -33,7 +62,7 @@ five-safes-crate:ResponsibleProjectMemberAndSourceOrganizationIntersection
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a schema:CreateAction ;
+              ?action a ro-crate:WorkflowRun ;
                       schema:agent ?this .
               ?this a schema:Person ;
                     schema:memberOf ?project ;

--- a/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
@@ -22,28 +22,57 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-# Person who is the agent of a CreateAction SHOULD have an affiliation
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
+# Person who is the agent of a WorkflowRun SHOULD have an affiliation
 five-safes-crate:PersonAgentHasAffiliation
     a sh:NodeShape ;
-    sh:name "Agent of CreateAction" ;
-    sh:description "The agent of a CreateAction entity" ;
+    sh:name "Agent of WorkflowRun" ;
+    sh:description "The agent of a WorkflowRun entity" ;
     sh:target [
         a sh:SPARQLTarget ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a schema:CreateAction ;
+              ?action a ro-crate:WorkflowRun ;
                       schema:agent ?this .
             }
         """
     ] ;
 
-    # The agent of a CreateAction entity SHOULD have an affiliation
+    # The agent of a WorkflowRun entity SHOULD have an affiliation
     sh:property [
         a sh:PropertyShape ;
         sh:name "Presence of affiliations" ;
         sh:path schema:affiliation ;
         sh:minCount 1 ;
         sh:severity sh:Warning ;
-        sh:message "The agent of a CreateAction entity SHOULD have an affiliation" ;
+        sh:message "The agent of a WorkflowRun entity SHOULD have an affiliation" ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
@@ -22,35 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 # Person who is the agent of a WorkflowRun SHOULD have an affiliation
 five-safes-crate:PersonAgentHasAffiliation
     a sh:NodeShape ;

--- a/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
@@ -45,5 +45,5 @@ five-safes-crate:PersonAgentHasAffiliation
         sh:path schema:affiliation ;
         sh:minCount 1 ;
         sh:severity sh:Warning ;
-        sh:message "The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation" ;
+        sh:message "The agent of the `CreateAction` corresponding to the workflow run SHOULD have an affiliation" ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
@@ -22,23 +22,23 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-# Person who is the agent of a WorkflowRun SHOULD have an affiliation
+# Person who is the agent of a WorkflowRunAction SHOULD have an affiliation
 five-safes-crate:PersonAgentHasAffiliation
     a sh:NodeShape ;
-    sh:name "Agent of WorkflowRun" ;
-    sh:description "The agent of a WorkflowRun entity" ;
+    sh:name "Agent of WorkflowRunAction" ;
+    sh:description "The agent of a WorkflowRunAction entity" ;
     sh:target [
         a sh:SPARQLTarget ;
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT DISTINCT ?this WHERE {
-              ?action a ro-crate:WorkflowRun ;
+              ?action a ro-crate:WorkflowRunAction ;
                       schema:agent ?this .
             }
         """
     ] ;
 
-    # The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation
+    # The agent of the `CreateAction` corresponding to the workflowrunAction SHOULD have an affiliation
     sh:property [
         a sh:PropertyShape ;
         sh:name "Presence of affiliations" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/2_requesting_agent.ttl
@@ -38,12 +38,12 @@ five-safes-crate:PersonAgentHasAffiliation
         """
     ] ;
 
-    # The agent of a WorkflowRun entity SHOULD have an affiliation
+    # The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation
     sh:property [
         a sh:PropertyShape ;
         sh:name "Presence of affiliations" ;
         sh:path schema:affiliation ;
         sh:minCount 1 ;
         sh:severity sh:Warning ;
-        sh:message "The agent of a WorkflowRun entity SHOULD have an affiliation" ;
+        sh:message "The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation" ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -22,35 +22,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
 # WorkflowRun SHOULD have object property with minimum cardinality 1
 five-safes-crate:WorkflowRunShouldHaveObjectProperty
     a sh:NodeShape ;

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -32,5 +32,5 @@ five-safes-crate:WorkflowRunShouldHaveObjectProperty
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Warning ;
-        sh:message "`WorkflowRun` SHOULD have the property `object` with IRI values." ;
+        sh:message "`CreateAction` (corresponding to the workflow run) SHOULD have the property `object` with IRI values." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -22,11 +22,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-# WorkflowRun SHOULD have object property with minimum cardinality 1
-five-safes-crate:WorkflowRunShouldHaveObjectProperty
+# WorkflowRunAction SHOULD have object property with minimum cardinality 1
+five-safes-crate:WorkflowRunActionShouldHaveObjectProperty
     a sh:NodeShape ;
-    sh:targetClass ro-crate:WorkflowRun ;
-    sh:name "WorkflowRun" ;
+    sh:targetClass ro-crate:WorkflowRunAction ;
+    sh:name "WorkflowRunAction" ;
     sh:property [
         sh:path schema:object ;
         sh:minCount 1 ;

--- a/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/7_requested_workflow_run.ttl
@@ -22,15 +22,44 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-# CreateAction SHOULD have object property with minimum cardinality 1
-five-safes-crate:CreateActionShouldHaveObjectProperty
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
+# WorkflowRun SHOULD have object property with minimum cardinality 1
+five-safes-crate:WorkflowRunShouldHaveObjectProperty
     a sh:NodeShape ;
-    sh:targetClass schema:CreateAction ;
-    sh:name "CreateAction" ;
+    sh:targetClass ro-crate:WorkflowRun ;
+    sh:name "WorkflowRun" ;
     sh:property [
         sh:path schema:object ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Warning ;
-        sh:message "`CreateAction` SHOULD have the property `object` with IRI values." ;
+        sh:message "`WorkflowRun` SHOULD have the property `object` with IRI values." ;
     ] .

--- a/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
@@ -24,36 +24,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
-ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
-    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
-    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
-    This is identified by checking that the CreateAction entity has an `instrument` property
-    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:prefixes ro-crate:sparqlPrefixes ;
-        sh:select """
-            SELECT ?this
-            WHERE {
-                ?this a schema:CreateAction ;
-                      schema:instrument ?instrument .
-                ?root schema:mainEntity ?instrument ;
-                      a schema:Dataset .
-                ?metadatafile schema:about ?root .
-                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
-            }
-        """
-    ] ;
-
-    sh:rule [
-        a sh:TripleRule ;
-        sh:subject sh:this ;
-        sh:predicate rdf:type ;
-        sh:object ro-crate:WorkflowRun ;
-    ] .
-
-
-
 five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
     a sh:NodeShape ;
     sh:name "Input" ;

--- a/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
@@ -33,7 +33,7 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this WHERE {
-              ?action a ro-crate:WorkflowRun ;
+              ?action a ro-crate:WorkflowRunAction ;
                       schema:object ?this .
             }
         """

--- a/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
+++ b/rocrate_validator/profiles/five-safes-crate/should/9_inputs.ttl
@@ -24,6 +24,35 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
+ro-crate:FindWorkflowRunAction a sh:NodeShape, validator:HiddenShape;
+    sh:name "Identify the CreateAction Entity that corresponds to the Workflow run" ;
+    sh:description """The Workflow Run is the CreateAction entity that refers to Workflow run.
+    This is identified by checking that the CreateAction entity has an `instrument` property
+    that references the same entity as the `mainEntity` property of the Root Data Entity.""" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a schema:CreateAction ;
+                      schema:instrument ?instrument .
+                ?root schema:mainEntity ?instrument ;
+                      a schema:Dataset .
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+            }
+        """
+    ] ;
+
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object ro-crate:WorkflowRun ;
+    ] .
+
+
 
 five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
     a sh:NodeShape ;
@@ -34,7 +63,7 @@ five-safes-crate:InputEntityReferencesFormalParameterViaExampleOfWork
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this WHERE {
-              ?action a schema:CreateAction ;
+              ?action a ro-crate:WorkflowRun ;
                       schema:object ?this .
             }
         """

--- a/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
@@ -60,6 +60,7 @@ ro-crate:RootDataEntityType
 
 
 ro-crate:FindRootDataEntity a sh:NodeShape, validator:HiddenShape;
+    sh:order 0 ;
     sh:name "Identify the Root Data Entity of the RO-Crate" ;
     sh:description """The Root Data Entity is the top-level Data Entity in the RO-Crate and serves as the starting point for the description of the RO-Crate.
         It is a schema:Dataset and is indirectly identified by the about property of the resource ro-crate-metadata.json in the RO-Crate 

--- a/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
@@ -60,7 +60,7 @@ ro-crate:RootDataEntityType
 
 
 ro-crate:FindRootDataEntity a sh:NodeShape, validator:HiddenShape;
-    sh:order 0 ;
+    sh:order 0 ; # load this check before any other check which has sh:order. pySHACL sorts rules by sh:order before execution
     sh:name "Identify the Root Data Entity of the RO-Crate" ;
     sh:description """The Root Data Entity is the top-level Data Entity in the RO-Crate and serves as the starting point for the description of the RO-Crate.
         It is a schema:Dataset and is indirectly identified by the about property of the resource ro-crate-metadata.json in the RO-Crate 

--- a/rocrate_validator/profiles/ro-crate/prefixes.ttl
+++ b/rocrate_validator/profiles/ro-crate/prefixes.ttl
@@ -46,4 +46,8 @@ ro-crate:sparqlPrefixes
     sh:declare [
         sh:prefix "ro" ;
         sh:namespace "./"^^xsd:anyURI ;
-    ] .
+    ] ;
+    sh:declare [
+        sh:prefix "ro-crate" ;
+        sh:namespace "https://github.com/crs4/rocrate-validator/profiles/ro-crate/"^^xsd:anyURI ;
+    ].

--- a/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
@@ -50,10 +50,10 @@ def test_completed_createaction_does_not_have_result():
         rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["WorkflowRun"],
+        expected_triggered_requirements=["WorkflowRunAction"],
         expected_triggered_issues=[
             "The `CreateAction` corresponding to the workflow run,",
-            "with CompletedActionStatus, SHOULD have the `result` property."
+            "with CompletedActionStatus, SHOULD have the `result` property.",
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
@@ -50,9 +50,9 @@ def test_completed_createaction_does_not_have_result():
         rocrate_path=ValidROC().five_safes_crate_result,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "`CreateAction` with CompletedActionStatus SHOULD have the `result` property."
+            "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_10_outputs.py
@@ -52,7 +52,8 @@ def test_completed_createaction_does_not_have_result():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "`WorkflowRun` with CompletedActionStatus SHOULD have the `result` property."
+            "The `CreateAction` corresponding to the workflow run,",
+            "with CompletedActionStatus, SHOULD have the `result` property."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -267,7 +267,7 @@ def test_5src_workflow_object_not_mentioned_by_root_data_entity():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)."
+            "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -267,7 +267,7 @@ def test_5src_workflow_object_not_mentioned_by_root_data_entity():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction)."
+            "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -47,7 +47,7 @@ def test_5src_workflow_object_with_no_name():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "Workflow (CreateAction) MUST have a name string of at least 10 characters."
+            "WorkflowRun MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -78,7 +78,7 @@ def test_5src_workflow_object_with_name_not_string():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "Workflow (CreateAction) MUST have a name string of at least 10 characters."
+            "WorkflowRun MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -109,7 +109,7 @@ def test_5src_workflow_object_with_not_long_enough_name():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "Workflow (CreateAction) MUST have a name string of at least 10 characters."
+            "WorkflowRun MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -203,7 +203,7 @@ def test_5src_workflow_object_with_no_action_status():
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
             (
-                "WorkflowExecution MUST have an actionStatus "
+                "WorkflowRun MUST have an actionStatus "
                 "with an allowed value (see https://schema.org/ActionStatusType)."
             )
         ],
@@ -236,7 +236,7 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
             (
-                "WorkflowExecution MUST have an actionStatus "
+                "WorkflowRun MUST have an actionStatus "
                 "with an allowed value (see https://schema.org/ActionStatusType)."
             )
         ],
@@ -267,7 +267,7 @@ def test_5src_workflow_object_not_mentioned_by_root_data_entity():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "RootDataEntity SHOULD mention workflow execution object (typed CreateAction)."
+            "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -47,7 +47,7 @@ def test_5src_workflow_object_with_no_name():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "WorkflowRun MUST have a name string of at least 10 characters."
+            "The `CreateAction` corresponding to the workflow run MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -78,7 +78,7 @@ def test_5src_workflow_object_with_name_not_string():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "WorkflowRun MUST have a name string of at least 10 characters."
+            "The `CreateAction` corresponding to the workflow run MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -109,7 +109,7 @@ def test_5src_workflow_object_with_not_long_enough_name():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
-            "WorkflowRun MUST have a name string of at least 10 characters."
+            "The `CreateAction` corresponding to the workflow run MUST have a name string of at least 10 characters."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -203,7 +203,7 @@ def test_5src_workflow_object_with_no_action_status():
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
             (
-                "WorkflowRun MUST have an actionStatus "
+                "`CreateAction` MUST have an actionStatus "
                 "with an allowed value (see https://schema.org/ActionStatusType)."
             )
         ],
@@ -236,7 +236,7 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
         expected_triggered_requirements=["WorkflowExecution"],
         expected_triggered_issues=[
             (
-                "WorkflowRun MUST have an actionStatus "
+                "`CreateAction` MUST have an actionStatus "
                 "with an allowed value (see https://schema.org/ActionStatusType)."
             )
         ],

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -267,7 +267,7 @@ def test_5src_workflow_object_not_mentioned_by_root_data_entity():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "RootDataEntity SHOULD mention workflow execution object (typed WorkflowRun)."
+            "RootDataEntity SHOULD mention a workflow run object (typed CreateAction)."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_11_workflow_execution.py
@@ -248,32 +248,6 @@ def test_5src_workflow_object_with_no_properly_valued_action_status():
 # ----- SHOULD fails tests
 
 
-def test_5src_workflow_object_not_mentioned_by_root_data_entity():
-    sparql = (
-        SPARQL_PREFIXES
-        + """
-        DELETE {
-            <./> schema:mentions ?o .
-        }
-        WHERE {
-            ?o rdf:type schema:CreateAction .
-        }
-        """
-    )
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_result,
-        requirement_severity=Severity.RECOMMENDED,
-        expected_validation_result=False,
-        expected_triggered_requirements=["RootDataEntity"],
-        expected_triggered_issues=[
-            "RootDataEntity SHOULD reference a workflow run entity (typed CreateAction) through `mentions`."
-        ],
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
 def test_5src_workflow_object_has_no_end_time_if_ended():
     sparql = (
         SPARQL_PREFIXES

--- a/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
@@ -158,7 +158,7 @@ def test_5src_agent_does_not_have_affiliation():
         expected_validation_result=False,
         expected_triggered_requirements=["Agent of WorkflowRun"],
         expected_triggered_issues=[
-            "The agent of a WorkflowRun entity SHOULD have an affiliation"
+            "The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
@@ -156,9 +156,9 @@ def test_5src_agent_does_not_have_affiliation():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["Agent of CreateAction"],
+        expected_triggered_requirements=["Agent of WorkflowRun"],
         expected_triggered_issues=[
-            "The agent of a CreateAction entity SHOULD have an affiliation"
+            "The agent of a WorkflowRun entity SHOULD have an affiliation"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
@@ -158,7 +158,7 @@ def test_5src_agent_does_not_have_affiliation():
         expected_validation_result=False,
         expected_triggered_requirements=["Agent of WorkflowRunAction"],
         expected_triggered_issues=[
-            "The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation"
+            "The agent of the `CreateAction` corresponding to the workflow run SHOULD have an affiliation"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_2_requesting_agent.py
@@ -156,7 +156,7 @@ def test_5src_agent_does_not_have_affiliation():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["Agent of WorkflowRun"],
+        expected_triggered_requirements=["Agent of WorkflowRunAction"],
         expected_triggered_issues=[
             "The agent of the `CreateAction` corresponding to the workflowrun SHOULD have an affiliation"
         ],

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -158,8 +158,8 @@ def test_createaction_object_does_not_reference_existing_entities():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowRunAction"],
         expected_triggered_issues=[
-            "Each `object` in the `CreateAction` entity corresponding"
-            + " to the workflow run MUST reference an existing entity."
+            "In the `CreateAction` entity corresponding to the workflow run,"
+            + " each `object`  MUST reference an existing entity."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -52,7 +52,8 @@ def test_rocrate_does_not_have_createaction():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`",
+            "`RootDataEntity` MUST reference at least one `CreateAction`",
+            " (corresponding to the workflow run) through `mentions`",
             "The crate MUST contain at least one `CreateAction` (corresponding to the workflow run)",
         ],
         profile_identifier="five-safes-crate",
@@ -83,7 +84,8 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`"
+            "`RootDataEntity` MUST reference at least one `CreateAction`",
+            " (corresponding to the workflow run) through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -116,7 +118,8 @@ def test_rootdataentity_does_not_mention_create_action():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`"
+            "`RootDataEntity` MUST reference at least one `CreateAction`",
+            " (corresponding to the workflow run) through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -151,7 +154,8 @@ def test_createaction_object_does_not_reference_existing_entities():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "Each `object` in the `CreateAction` entity corresponding to the workflow run MUST reference an existing entity."
+            "Each `object` in the `CreateAction` entity corresponding" +
+            " to the workflow run MUST reference an existing entity."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -85,7 +85,7 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
             "`RootDataEntity` MUST reference at least one `CreateAction`",
-            " (corresponding to the workflow run) through `mentions`"
+            " (corresponding to the workflow run) through `mentions`",
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -119,7 +119,7 @@ def test_rootdataentity_does_not_mention_create_action():
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
             "`RootDataEntity` MUST reference at least one `CreateAction`",
-            " (corresponding to the workflow run) through `mentions`"
+            " (corresponding to the workflow run) through `mentions`",
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -152,10 +152,10 @@ def test_createaction_object_does_not_reference_existing_entities():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=["WorkflowRun"],
+        expected_triggered_requirements=["WorkflowRunAction"],
         expected_triggered_issues=[
-            "Each `object` in the `CreateAction` entity corresponding" +
-            " to the workflow run MUST reference an existing entity."
+            "Each `object` in the `CreateAction` entity corresponding"
+            + " to the workflow run MUST reference an existing entity."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -187,7 +187,7 @@ def test_createaction_does_not_have_object_property():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["WorkflowRun"],
+        expected_triggered_requirements=["WorkflowRunAction"],
         expected_triggered_issues=[
             "`CreateAction` (corresponding to the workflow run) SHOULD have the property `object` with IRI values."
         ],

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -55,9 +55,9 @@ def test_rocrate_does_not_have_createaction():
             "`RootDataEntity` MUST reference at least one `CreateAction`",
             " (corresponding to the workflow run) through `mentions`",
             (
-                "The `CreateAction` entity corresponding to the workflow run "
-                "MUST reference through its property `instrument` the same "
-                "entity as `RootData Entity` --> `mainEntity`"
+                "The CreateAction entity corresponding to the workflow MUST "
+                "reference, as an instrument, the entity that is referenced "
+                "as mainEntity by the RO-Crate"
             ),
         ],
         profile_identifier="five-safes-crate",

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -54,7 +54,11 @@ def test_rocrate_does_not_have_createaction():
         expected_triggered_issues=[
             "`RootDataEntity` MUST reference at least one `CreateAction`",
             " (corresponding to the workflow run) through `mentions`",
-            "The crate MUST contain at least one `CreateAction` (corresponding to the workflow run)",
+            (
+                "The `CreateAction` entity corresponding to the workflow run "
+                "MUST reference through its property `instrument` the same "
+                "entity as `RootData Entity` --> `mainEntity`"
+            ),
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -52,8 +52,8 @@ def test_rocrate_does_not_have_createaction():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`",
-            "The crate MUST contain at least one `WorkflowRun` entity",
+            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`",
+            "The crate MUST contain at least one `CreateAction` (corresponding to the workflow run)",
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -83,7 +83,7 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`"
+            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -116,7 +116,7 @@ def test_rootdataentity_does_not_mention_create_action():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`"
+            "`RootDataEntity` MUST reference at least one `CreateAction` (corresponding to the workflow run) through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -151,7 +151,7 @@ def test_createaction_object_does_not_reference_existing_entities():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "Each `object` in `WorkflowRun` MUST reference an existing entity."
+            "Each `object` in the `CreateAction` entity corresponding to the workflow run MUST reference an existing entity."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -185,7 +185,7 @@ def test_createaction_does_not_have_object_property():
         expected_validation_result=False,
         expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "`WorkflowRun` SHOULD have the property `object` with IRI values."
+            "`CreateAction` (corresponding to the workflow run) SHOULD have the property `object` with IRI values."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
+++ b/tests/integration/profiles/five-safes-crate/test_5src_7_requesting_workflow_run.py
@@ -52,7 +52,8 @@ def test_rocrate_does_not_have_createaction():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
+            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`",
+            "The crate MUST contain at least one `WorkflowRun` entity",
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -82,7 +83,7 @@ def test_rootdataentity_does_not_have_mentions_property():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
+            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -115,73 +116,7 @@ def test_rootdataentity_does_not_mention_create_action():
         expected_validation_result=False,
         expected_triggered_requirements=["RootDataEntity"],
         expected_triggered_issues=[
-            "`RootDataEntity` MUST reference at least one `CreateAction` through `mentions`"
-        ],
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_createaction_does_not_have_instrument_property():
-    """
-    Test a Five Safes Crate where `CreateAction` does not have the property `instrument`.
-    (We remove the property `instrument` from the `CreateAction` entity)
-    """
-    sparql = (
-        SPARQL_PREFIXES
-        + """
-        DELETE {
-            ?action schema:instrument ?o .
-        }
-        WHERE {
-           ?action schema:instrument ?o ;
-                   a schema:CreateAction .
-        }
-        """
-    )
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.REQUIRED,
-        expected_validation_result=False,
-        expected_triggered_requirements=["CreateAction"],
-        expected_triggered_issues=[
-            "`CreateAction` MUST have the `instrument` property"
-        ],
-        profile_identifier="five-safes-crate",
-        rocrate_entity_mod_sparql=sparql,
-    )
-
-
-def test_createaction_does_not_reference_mainentity_via_instrument():
-    """
-    Test a Five Safes Crate where `CreateAction` --> `instrument` does not
-    reference `mainEntity`.
-    (We replace `mainEntity` with a literal as the object of `CreateAction` --> `instrument`)
-    """
-    sparql = (
-        SPARQL_PREFIXES
-        + """
-        DELETE {
-            ?action schema:instrument ?o .
-        }
-        INSERT {
-            ?action schema:instrument "This is not the mainEntity" .
-        }
-        WHERE {
-           ?action schema:instrument ?o ;
-                   a schema:CreateAction .
-        }
-        """
-    )
-
-    do_entity_test(
-        rocrate_path=ValidROC().five_safes_crate_request,
-        requirement_severity=Severity.REQUIRED,
-        expected_validation_result=False,
-        expected_triggered_requirements=["CreateAction"],
-        expected_triggered_issues=[
-            "`CreateAction` --> `instrument` MUST reference the same entity as `Root Data Entity` --> `mainEntity`"
+            "`RootDataEntity` MUST reference at least one `WorkflowRun` through `mentions`"
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -214,9 +149,9 @@ def test_createaction_object_does_not_reference_existing_entities():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.REQUIRED,
         expected_validation_result=False,
-        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "Each `object` in `CreateAction` MUST reference an existing entity."
+            "Each `object` in `WorkflowRun` MUST reference an existing entity."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,
@@ -248,9 +183,9 @@ def test_createaction_does_not_have_object_property():
         rocrate_path=ValidROC().five_safes_crate_request,
         requirement_severity=Severity.RECOMMENDED,
         expected_validation_result=False,
-        expected_triggered_requirements=["CreateAction"],
+        expected_triggered_requirements=["WorkflowRun"],
         expected_triggered_issues=[
-            "`CreateAction` SHOULD have the property `object` with IRI values."
+            "`WorkflowRun` SHOULD have the property `object` with IRI values."
         ],
         profile_identifier="five-safes-crate",
         rocrate_entity_mod_sparql=sparql,

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -118,9 +118,9 @@ def do_entity_test(
 
     Additional keyword arguments (kwargs) are passed along to initialise ValidationSettings.
     """
-    assert not (
-        rocrate_entity_patch and rocrate_entity_mod_sparql
-    ), "Cannot use rocrate_entity_patch and rocrate_entity_mod_sparql together"
+    assert not (rocrate_entity_patch and rocrate_entity_mod_sparql), (
+        "Cannot use rocrate_entity_patch and rocrate_entity_mod_sparql together"
+    )
 
     # declare variables
     failed_requirements = None
@@ -198,9 +198,9 @@ def do_entity_test(
 
         assert result.context is not None, "Validation context should not be None"
         f"Expected requirement severity to be {requirement_severity}, but got {result.context.requirement_severity}"
-        assert (
-            result.passed() == expected_validation_result
-        ), f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
+        assert result.passed() == expected_validation_result, (
+            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
+        )
 
         # check requirement
         failed_requirements = [_.name for _ in result.failed_requirements]
@@ -228,9 +228,9 @@ def do_entity_test(
             if not any(
                 expected_issue in issue for issue in detected_issues
             ):  # support partial match
-                assert (
-                    False
-                ), f'The expected issue "{expected_issue}" was not found in the detected issues'
+                assert False, (
+                    f'The expected issue "{expected_issue}" was not found in the detected issues'
+                )
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.exception(e)


### PR DESCRIPTION
Closes #43.

**NOTE:** This PR supersedes #104. The current commit on this branch addresses all the comments made on #104.

---

This PR implements a solution for treating the workflow-execution `CreateAction` as a dedicated `ro-crate:WorkflowRun` entity across the Five Safes SHACL profiles.

At a high level:

* A hidden SHACL rule was added to the relevant TTL files to infer the triple `CreateAction -> rdf:type -> ro-crate:WorkflowRun` for the `CreateAction` whose `instrument` matches `RootDataEntity -> mainEntity`.

* All SHACL constraints that are really about the actual workflow run were then retargeted from generic `CreateAction` to `WorkflowRun`, with corresponding updates on shapes' names and  messages.

* Tests were updated accordingly.

One important testing detail:

* In the Python tests, the graph mutations still target entities of type `CreateAction`, not `WorkflowRun`.

* This is intentional: `WorkflowRun` is inferred by SHACL during validation, so it is safer for the tests to alter the source `CreateAction` nodes in the RO-Crate metadata graph.

* This remains correct as long as the tests are understood to target the specific `CreateAction` that is effectively the workflow run, and not any other `CreateAction` that may also be present in the crate.

A separate consistency note:

* In `prefixes.ttl`, the RO-Crate namespace is exposed in SPARQL via `rocrate` (without the dash), while elsewhere in the codebase we also use `ro-crate`.
This did not originate in this PR, but it is something we may want to clean up in future to align prefix syntax across the codebase.